### PR TITLE
check for ActiveRecord (to handle non AR apps)

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -31,9 +31,11 @@ namespace :perf do
     else
       APP.initialize! unless APP.instance_variable_get(:@initialized)
     end
-    ActiveRecord::Migrator.migrations_paths = APP.paths['db/migrate'].to_a
-    ActiveRecord::Migration.verbose = true
-    ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, nil)
+    if defined? ActiveRecord
+      ActiveRecord::Migrator.migrations_paths = APP.paths['db/migrate'].to_a
+      ActiveRecord::Migration.verbose = true
+      ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, nil)
+    end
 
     APP.config.consider_all_requests_local = true
 


### PR DESCRIPTION
We don't use AR (we use mongo only) so the tests wouldn't run. I just added a conditional to check if AR was defined.
