### PR TITLE
Change rake dependency from 10.4 to 10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       get_process_mem (~> 0)
       memory_profiler (~> 0)
       rack (~> 1)
-      rake (~> 10.4)
+      rake (~> 10)
 
 GEM
   remote: https://rubygems.org/
@@ -40,7 +40,7 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.3)
     bcrypt (3.1.10)
-    benchmark-ips (2.1.1)
+    benchmark-ips (2.2.0)
     builder (3.0.4)
     capybara (2.4.4)
       mime-types (>= 1.16)

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "get_process_mem", "~> 0"
   gem.add_dependency "benchmark-ips",   "~> 2"
   gem.add_dependency "rack",            "~> 1"
-  gem.add_dependency "rake",            "~> 10.4"
+  gem.add_dependency "rake",            "~> 10"
 
   gem.add_development_dependency "capybara", "~> 2"
   gem.add_development_dependency "rails",    "~> 3"


### PR DESCRIPTION
Relaxing rake dependency to reduce version conflicts, as seen in #29 