### PR TITLE
Display more info about duplicate requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,35 @@ You can use `CUT_OFF=0.3` to only show files that have above a certain memory us
 
 Note: This method won't include files in your own app, only items in your Gemfile. For that you'll need to use `derailed exec mem`. See below for more info.
 
+The same file may be required by several libraries, since Ruby only requires files once, the cost is only associated with the first library to require a file. To make this more visible duplicate entries will list all the parents they belong to. For example both `mail` and `fog` require `mime/types. So it may show up something like this in your app:
+
+```
+$ derailed bundle:mem
+TOP: 54.1836 MiB
+  mail: 18.9688 MiB
+    mime/types: 17.4453 MiB (Also required by: fog/storage)
+    mail/field: 0.4023 MiB
+    mail/message: 0.3906 MiB
+```
+
+That way you'll know that simply removing the top level library (mail) would not result in a memory reduction. The output is trucated after the first two entries:
+
+
+```
+fog/core: 0.9844 MiB (Also required by: fog/xml, fog/json, and 48 others)
+fog/rackspace: 0.957 MiB
+fog/joyent: 0.7227 MiB
+  fog/joyent/compute: 0.7227 MiB
+```
+
+If you want to see everything that requires `fog/core` you can run `CUT_OFF=0 bundle exec derailed bundle:mem` to get the full output that you can then grep through manually.
+
+Update: While `mime/types` looks horible in these examples, it's been fixed. You can add this to the top of your gemfile for free memory:
+
+```ruby
+gem 'mime-types', '~> 2.4.3', require: 'mime/types/columnar'
+```
+
 ### Objects created at Require time
 
 To get more info about the objects, using [memory_profiler](https://github.com/SamSaffron/memory_profiler), created when your dependencies are required you can run:

--- a/bin/derailed
+++ b/bin/derailed
@@ -22,6 +22,7 @@ class DerailedBenchmarkCLI < Thor
 
   desc "exec", "executes given derailed benchmark"
   def exec(task = nil)
+    setup_bundler!
     require 'derailed_benchmarks'
     require 'rake'
     Rake::TaskManager.record_task_metadata = true

--- a/bin/derailed
+++ b/bin/derailed
@@ -13,7 +13,7 @@ $: << lib
 
 
 require File.join(lib, 'derailed_benchmarks.rb')
-require 'bundler'
+
 Bundler.setup
 
 require 'thor'

--- a/lib/derailed_benchmarks.rb
+++ b/lib/derailed_benchmarks.rb
@@ -1,10 +1,7 @@
 require 'time'
-
-require 'rack/test'
-require 'rack/file'
-require 'benchmark/ips'
-require 'get_process_mem'
 require 'bundler'
+
+require 'get_process_mem'
 
 module DerailedBenchmarks
   def self.gem_is_bundled?(name)

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -1,4 +1,3 @@
-
 namespace :perf do
   task :rails_load do
     ENV["RAILS_ENV"] ||= "production"
@@ -66,6 +65,9 @@ namespace :perf do
     TEST_COUNT  = (ENV['TEST_COUNT'] || ENV['CNT'] || 1_000).to_i
     PATH_TO_HIT = ENV["PATH_TO_HIT"] || ENV['ENDPOINT'] || "/"
     puts "Endpoint: #{ PATH_TO_HIT.inspect }"
+
+    require 'rack/test'
+    require 'rack/file'
 
     DERAILED_APP = DerailedBenchmarks.add_auth(DERAILED_APP)
     if server = ENV["USE_SERVER"]
@@ -145,6 +147,7 @@ namespace :perf do
 
   desc "outputs ram usage over time"
   task :ram_over_time => [:setup] do
+    require 'get_process_mem'
     puts "PID: #{Process.pid}"
     ram = GetProcessMem.new
     @keep_going = true
@@ -177,6 +180,8 @@ namespace :perf do
 
   desc "iterations per second"
   task :ips => [:setup] do
+    require 'benchmark/ips'
+
     Benchmark.ips do |x|
       x.report("ips") { call_app }
     end


### PR DESCRIPTION
The same file may be required by several libraries, since Ruby only requires files once, the cost is only associated with the first library to require a file. To make this more visible duplicate entries will list all the parents they belong to. For example both `mail` and `fog` require `mime/types. So it may show up something like this in your app:

```
$ derailed bundle:mem
TOP: 54.1836 MiB
  mail: 18.9688 MiB
    mime/types: 17.4453 MiB (Also required by: fog/storage)
    mail/field: 0.4023 MiB
    mail/message: 0.3906 MiB
```

That way you'll know that simply removing the top level library (mail) would not result in a memory reduction. The output is trucated after the first two entries:


```
fog/core: 0.9844 MiB (Also required by: fog/xml, fog/json, and 48 others)
fog/rackspace: 0.957 MiB
fog/joyent: 0.7227 MiB
  fog/joyent/compute: 0.7227 MiB
```

If you want to see everything that requires `fog/core` you can run `CUT_OFF=0 bundle exec derailed bundle:mem` to get the full output that you can then grep through manually.