### PR TITLE
Add thor as an explicit gem dependency

### DIFF
--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "benchmark-ips",   "~> 2"
   gem.add_dependency "rack",            "~> 1"
   gem.add_dependency "rake",            "~> 10"
+  gem.add_dependency "thor",            "~> 0.19"
 
   gem.add_development_dependency "capybara", "~> 2"
   gem.add_development_dependency "rails",    "~> 3"


### PR DESCRIPTION
When using `derailed` outside of rails, it fails unless `thor` happens to be loaded by something else in the `Gemfile`

### Steps to reproduce the problem:

Create and `bundle install` following `Gemfile`:

```
source 'https://rubygems.org'
ruby '2.2.2'

gem 'derailed'
gem 'stackprof'
gem 'pg' # <-- some gem I am curious about, but does not depend on thor
```

then

```
➜  perf-play  bundle exec derailed bundle:mem
/Users/eoinkelly/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/derailed_benchmarks-1.0.1/bin/derailed:19:in `require': cannot load such file -- thor (LoadError)
	from /Users/eoinkelly/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/derailed_benchmarks-1.0.1/bin/derailed:19:in `<top (required)>'
	from /Users/eoinkelly/.rbenv/versions/2.2.2/bin/derailed:23:in `load'
	from /Users/eoinkelly/.rbenv/versions/2.2.2/bin/derailed:23:in `<main>'
```

This can be worked around by adding `gem "thor"` to `Gemfile` but having thor be an explicit gem dependency is better I think.