### PR TITLE
Make copy-paste gem to Gemfile smooth [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ While executing your commands you may need to use `bundle exec` before typing th
 To use all profiling methods available also add:
 
 ```
-gem "stackprof", group: :development
+gem 'stackprof', group: :development
 ```
 
 You must be using Ruby 2.1+ to install these libraries. If you're on an older version of Ruby, what are you waiting for?


### PR DESCRIPTION
<img width="404" alt="screenshot 2015-08-11 15 10 36" src="https://cloud.githubusercontent.com/assets/1000669/9192176/246949d0-403b-11e5-9b2d-fe80ceb69db6.png">

Make quotes the same so when paste these two gems to Gemfile, do not need to change if single quote is want one wants.