### PR TITLE
Fix redefined constant warning

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -114,7 +114,7 @@ namespace :perf do
     rescue LoadError
       raise "Add stackprof to your gemfile to continue `gem 'stackprof', group: :development`"
     end
-    TEST_COUNT = (ENV["TEST_COUNT"] ||= "100").to_i
+    STACKPROF_TEST_COUNT = (ENV["TEST_COUNT"] ||= "100").to_i
     file = "tmp/#{Time.now.iso8601}-stackprof-cpu-myapp.dump"
     StackProf.run(mode: :cpu, out: file) do
       Rake::Task["perf:test"].invoke

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -69,13 +69,13 @@ namespace :perf do
     require 'rack/test'
     require 'rack/file'
 
-    DERAILED_APP = DerailedBenchmarks.add_auth(DERAILED_APP)
+    DERAILED_AUTHED_APP = DerailedBenchmarks.add_auth(DERAILED_APP)
     if server = ENV["USE_SERVER"]
       @port = (3000..3900).to_a.sample
       puts "Port: #{ @port.inspect }"
       puts "Server: #{ server.inspect }"
       thread = Thread.new do
-        Rack::Server.start(app: DERAILED_APP, :Port => @port, environment: "none", server: server)
+        Rack::Server.start(app: DERAILED_AUTHED_APP, :Port => @port, environment: "none", server: server)
       end
       sleep 1
 
@@ -85,7 +85,7 @@ namespace :perf do
         raise "Bad request to #{cmd.inspect} Response:\n#{ response.inspect }" unless $?.success?
       end
     else
-      @app = Rack::MockRequest.new(DERAILED_APP)
+      @app = Rack::MockRequest.new(DERAILED_AUTHED_APP)
 
       def call_app
         response = @app.get(PATH_TO_HIT)


### PR DESCRIPTION
This pull request fixes following warnings:

```
$ bundle exec derailed exec perf:stackprof
Booting: production
Endpoint: "/"
/Users/Juan/.gem/ruby/2.2.2/gems/derailed_benchmarks-1.0.1/lib/derailed_benchmarks/tasks.rb:72:
warning: already initialized constant DERAILED_APP
/Users/Juan/.gem/ruby/2.2.2/gems/derailed_benchmarks-1.0.1/lib/derailed_benchmarks/tasks.rb:23:
warning: previous definition of DERAILED_APP was here
/Users/Juan/.gem/ruby/2.2.2/gems/derailed_benchmarks-1.0.1/lib/derailed_benchmarks/tasks.rb:117:
warning: already initialized constant TEST_COUNT
/Users/Juan/.gem/ruby/2.2.2/gems/derailed_benchmarks-1.0.1/lib/derailed_benchmarks/tasks.rb:65:
warning: previous definition of TEST_COUNT was here
```

Naming
- [x]  `DERAILED_AUTHED_APP`, :ok_hand: :question: 
- [x]  `STACKPROF_TEST_UNIT`, :ok_hand: :grey_question: 
- [ ] Release v1.0.2

--

ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]