### PR TITLE
Require benchmark in perf:test task

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -97,6 +97,8 @@ namespace :perf do
 
   desc "hits the url TEST_COUNT times"
   task :test => [:setup] do
+    require 'benchmark'
+
     Benchmark.bm { |x|
       x.report("#{TEST_COUNT} requests") {
         TEST_COUNT.times {


### PR DESCRIPTION
Executing `bundle exec derailed exec perf:test` it's raising an exception because `Benchmark` isn't loaded: 
```
/var/lib/gems/2.1.0/gems/derailed_benchmarks-1.0.1/lib/derailed_benchmarks/tasks.rb:102:in `block (2 levels) in <top (required)>': uninitialized constant Benchmark (NameError)
```
It's solved just requiring it. 