### PR TITLE
Fix temp file names for ram_over_time

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -155,7 +155,7 @@ namespace :perf do
     @keep_going = true
     begin
       unless ENV["SKIP_FILE_WRITE"]
-        ruby = `ruby -v`
+        ruby = `ruby -v`.chomp
         FileUtils.mkdir_p("tmp")
         file = File.open("tmp/#{Time.now.iso8601}-#{ruby}-memory-#{TEST_COUNT}-times.txt", 'w')
         file.sync = true


### PR DESCRIPTION
The temp file generated, at least on OS X, was invalid in some manner.
It would end up splitting into two files - one that contained the
time stamp and output from `ruby -v` and the other that contained the
rest of the file name. Neither of these files ever had any actual output
recorded to them.

None of the other logs have the ruby version in them so instead of
trying to figure out what characters OS X wasn't liking, I just removed
the ruby version from the name.