### PR TITLE
Set custom auth user using a lambda in perf.rake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # A Log of Changes!
 
+## [1.1.0] - unreleased
+- Set custom auth user using a lambda in perf.rake
+
 ## [1.0.1] - 2015-20-06
 
 - `bundle:mem` and similar tasks now keep track of duplicate requires and display them along side of memory requirements. This makes it easier to identify where components are used by multiple libraries

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       memory_profiler (~> 0)
       rack (~> 1)
       rake (~> 10)
+      thor (~> 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -40,7 +41,7 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.3)
     bcrypt (3.1.10)
-    benchmark-ips (2.2.0)
+    benchmark-ips (2.3.0)
     builder (3.0.4)
     capybara (2.4.4)
       mime-types (>= 1.16)
@@ -64,7 +65,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    memory_profiler (0.9.1)
+    memory_profiler (0.9.4)
     mime-types (1.25.1)
     mini_portile (0.6.2)
     multi_json (1.11.0)
@@ -131,3 +132,6 @@ DEPENDENCIES
   rails (~> 3)
   sqlite3
   test-unit (~> 3.0)
+
+BUNDLED WITH
+   1.10.5

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ $ cat perf.rake
 If you want you can customize the user that is logged in by setting that value in your `perf.rake` file.
 
 ```
-DerailedBenchmarks.auth.user = User.find_or_create!(twitter: "schneems")
+DerailedBenchmarks.auth.user = -> { User.find_or_create!(twitter: "schneems") }
 ```
 
 You will need to provide a valid user, so depending on the validations you have in your `user.rb`, you may need to provide different parameters.

--- a/lib/derailed_benchmarks/auth_helpers/devise.rb
+++ b/lib/derailed_benchmarks/auth_helpers/devise.rb
@@ -4,7 +4,7 @@ module DerailedBenchmarks
     # Setup adds necessarry test methods, user provides a sample user.
     # The authenticate method is called on every request when authentication is enabled
     class Devise < AuthHelper
-      attr_accessor :user
+      attr_writer :user
 
       # Include devise test helpers and turn on test mode
       # We need to do this on the class level
@@ -19,9 +19,12 @@ module DerailedBenchmarks
       end
 
       def user
-        @user ||= begin
+        if @user
+          @user = @user.call if @user.is_a?(Proc)
+          @user
+        else
           password = SecureRandom.hex
-          User.first_or_create!(email: "#{SecureRandom.hex}@example.com", password: password, password_confirmation: password)
+          @user = User.first_or_create!(email: "#{SecureRandom.hex}@example.com", password: password, password_confirmation: password)
         end
       end
 

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -36,6 +36,12 @@ class TasksTest < ActiveSupport::TestCase
     assert_match 'Server: "webrick"', result
   end
 
+  test 'authenticate with a custom user' do
+    env = { "AUTH_CUSTOM_USER" => "true", "PATH_TO_HIT" => "authenticated", "USE_AUTH" => "true", "TEST_COUNT" => "2" }
+    result = rake 'perf:test', env: env
+    assert_match 'Auth: true', result
+  end
+
   test 'test' do
     rake "perf:test"
   end

--- a/test/rails_app/perf.rake
+++ b/test/rails_app/perf.rake
@@ -2,3 +2,7 @@ $LOAD_PATH << File.expand_path("../../../lib", __FILE__)
 
 require 'derailed_benchmarks'
 require 'derailed_benchmarks/tasks'
+
+if ENV['AUTH_CUSTOM_USER']
+  DerailedBenchmarks.auth.user = -> { User.first_or_create!(email: "user@example.com", password: 'password') }
+end


### PR DESCRIPTION
Fixes #51 and #35 by allowing a lambda to set a custom user in perf.rake

```ruby
DerailedBenchmarks.auth.user = -> { User.find_or_create!(twitter: "schneems") }
```

I added the new syntax to the README and an integration test to check that it works.
