### PR TITLE
Fix syntax in devise auth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ $ cat perf.rake
 If you want you can customize the user that is logged in by setting that value in your `perf.rake` file.
 
 ```
-DerailedBenchmarks.auth.user = -> { User.find_or_create!(twitter: "schneems") }
+DerailedBenchmarks.auth.user = -> { User.first_or_create!(twitter: "schneems") }
 ```
 
 You will need to provide a valid user, so depending on the validations you have in your `user.rb`, you may need to provide different parameters.


### PR DESCRIPTION
to avoid error:

```
NoMethodError: undefined method `find_or_create!'
```