### PR TITLE
Create /tmp directory if doesn't exist

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -269,7 +269,7 @@ namespace :perf do
     require 'objspace'
 
     file_name = "tmp/#{Time.now.iso8601}-heap.dump"
-    FileUtils.mkdir_p file_name
+    FileUtils.mkdir_p("tmp")
     ObjectSpace.trace_object_allocations_start
     puts "Running #{ TEST_COUNT } times"
     TEST_COUNT.times {

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -269,6 +269,7 @@ namespace :perf do
     require 'objspace'
 
     file_name = "tmp/#{Time.now.iso8601}-heap.dump"
+    FileUtils.mkdir_p file_name
     ObjectSpace.trace_object_allocations_start
     puts "Running #{ TEST_COUNT } times"
     TEST_COUNT.times {


### PR DESCRIPTION
Basically to save us from below error.

 **No such file or directory @ rb_sysopen - tmp/2015-10-05T21:49:15-07:00-heap.dump (Errno::ENOENT)** .  I removed the `/tmp` folder sometime back and gave this error on `bundle exec derailed exec perf:heap`

```ruby
Booting: production
db/production.sqlite3 already exists
Endpoint: "/"
/Users/agupta/.rvm/gems/ruby-2.2.2/gems/derailed_benchmarks-1.1.2/lib/derailed_benchmarks/tasks.rb:72: warning: already initialized constant DERAILED_APP
/Users/agupta/.rvm/gems/ruby-2.2.2/gems/derailed_benchmarks-1.1.2/lib/derailed_benchmarks/tasks.rb:23: warning: previous definition of DERAILED_APP was here
Running 1000 times
Heap file generated: "tmp/2015-10-05T21:49:15-07:00-heap.dump"
/Users/agupta/.rvm/gems/ruby-2.2.2/gems/derailed_benchmarks-1.1.2/lib/derailed_benchmarks/tasks.rb:280:in `initialize': No such file or directory @ rb_sysopen - tmp/2015-10-05T21:49:15-07:00-heap.dump (Errno::ENOENT)
	from /Users/agupta/.rvm/gems/ruby-2.2.2/gems/derailed_benchmarks-1.1.2/lib/derailed_benchmarks/tasks.rb:280:in `open'
	from /Users/agupta/.rvm/gems/ruby-2.2.2/gems/derailed_benchmarks-
   #....
agupta01sjl:rdc-next agupta$ bundle exec derailed exec perf:heap
```