### PR TITLE
Improve devise authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,11 @@ $ cat perf.rake
 If you want you can customize the user that is logged in by setting that value in your `perf.rake` file.
 
 ```
-DerailedBenchmarks.auth.user = -> { User.find_or_create!(twitter: "schneems") }
+DerailedBenchmarks.auth.user = -> { 
+  User.where(twitter: "schneems").first_or_create do |user|
+    user.password = "12345"
+  end
+}
 ```
 
 You will need to provide a valid user, so depending on the validations you have in your `user.rb`, you may need to provide different parameters.


### PR DESCRIPTION
The change here is twofold:

1. The previous example was failing
2. It did not account for a very common use case, of the user needing a password to be created

This addresses those issues by using `first_or_create` which will still take advantage of a finding a user by the specific criteria, if there is one on the db, or it will give you one in the block so you can play around with it and set the attributes you need.

I believe this is better of a default than #54, thus a different PR to solve the same issue.