### PR TITLE
Add environment variable check before using ActiveRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,13 @@ This boots a webserver and hits it using `curl` instead of in memory. This is us
 
 Note: this plugs in the given webserver directly into rack, it doesn't use any `puma.config` file etc. that you have set-up. If you want to do this, i'm open to suggestions on how (and pull requests)
 
+### Excluding ActiveRecord
+
+By default, derailed will load ActiveRecord if the gem is included as a dependency.  It is included by default, if you just include the `rails` gem.  If you are using a different ORM, you will either need to only include the `railties` gem, or set the `DERAILED_SKIP_ACTIVE_RECORD` flag.
+
+```
+$ DERAILED_SKIP_ACTIVE_RECORD=true
+```
 
 ### Running in a different environment
 

--- a/bin/derailed
+++ b/bin/derailed
@@ -76,7 +76,7 @@ class DerailedBenchmarkCLI < Thor
       require 'bundler/setup'
 
       begin
-        if ENV["DERAILED_SKIP_ACTIVE_RECORD"] == "true"
+        if ENV["DERAILED_SKIP_ACTIVE_RECORD"]
           require "action_controller/railtie"
           require "action_mailer/railtie"
           require "sprockets/railtie"

--- a/bin/derailed
+++ b/bin/derailed
@@ -76,7 +76,14 @@ class DerailedBenchmarkCLI < Thor
       require 'bundler/setup'
 
       begin
-        require 'rails/all'
+        if ENV["DERAILED_SKIP_ACTIVE_RECORD"] == "true"
+          require "action_controller/railtie"
+          require "action_mailer/railtie"
+          require "sprockets/railtie"
+          require "rails/test_unit/railtie"
+        else
+          require 'rails/all'
+        end
       rescue LoadError
       end
     end

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -28,7 +28,7 @@ namespace :perf do
       DERAILED_APP.initialize! unless DERAILED_APP.instance_variable_get(:@initialized)
     end
 
-    if defined? ActiveRecord
+    if  ENV["DERAILED_SKIP_ACTIVE_RECORD"] != "true" && defined? ActiveRecord
       if defined? ActiveRecord::Tasks::DatabaseTasks
         ActiveRecord::Tasks::DatabaseTasks.create_current
       else # Rails 3.2

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -28,7 +28,7 @@ namespace :perf do
       DERAILED_APP.initialize! unless DERAILED_APP.instance_variable_get(:@initialized)
     end
 
-    if  ENV["DERAILED_SKIP_ACTIVE_RECORD"] != "true" && defined? ActiveRecord
+    if  ENV["DERAILED_SKIP_ACTIVE_RECORD"] && defined? ActiveRecord
       if defined? ActiveRecord::Tasks::DatabaseTasks
         ActiveRecord::Tasks::DatabaseTasks.create_current
       else # Rails 3.2


### PR DESCRIPTION
This lets you set the environment variable `DERAILED_SKIP_ACTIVE_RECORD=true` if you aren't using ActiveRecord as your ORM.

I wasn't sure what the best place to add documentation for this would be - let me know and I'll add it.