### PR TITLE
Leep log level if defined

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -6,7 +6,7 @@ namespace :perf do
 
     ENV["SECRET_KEY_BASE"] ||= "foofoofoo"
 
-    ENV['LOG_LEVEL'] = "FATAL"
+    ENV['LOG_LEVEL'] ||= "FATAL"
 
     require 'rails'
 


### PR DESCRIPTION
If `ENV['LOG_LEVEL']` is present, do not set it to "FATAL" (for setting custom levels).