### PR TITLE
Define `required_ruby_version` for >= 2.1.0

### DIFF
--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = ">= 2.1.0"
+
   gem.add_dependency "heapy",           "~> 0"
   gem.add_dependency "memory_profiler", "~> 0"
   gem.add_dependency "get_process_mem", "~> 0"


### PR DESCRIPTION
Derailed benchmarks depends on `memory_profiler` which [requires the
Ruby version to be >= 2.1.0](https://github.com/SamSaffron/memory_profiler/blob/master/memory_profiler.gemspec#L18). This updates the gemspec to reflect that
need.