### PR TITLE
Add minimum Ruby version to gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0
   - 2.1
   - 2.2
   - ruby-head
@@ -11,6 +9,4 @@ before_install:
 
 matrix:
   allow_failures:
-    - rvm: 1.9.3
-    - rvm: 2.0
     - rvm: ruby-head

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = ">= 2.1.0"
+
   gem.add_dependency "heapy",           "~> 0"
   gem.add_dependency "memory_profiler", "~> 0"
   gem.add_dependency "get_process_mem", "~> 0"


### PR DESCRIPTION
Updates the minimum Ruby version to be newer than 2.1.0 since the
following dependencies need to be met:

- memory_profiler wants >= 2.1.0
- rack wants >= 2.2.0

This also updates CI to only run the newer versions of Ruby since < 2.1
shouldn't work anyway and there is no point having "allowed failures" if
it will always fail.

Updated with feedback from #87