### PR TITLE
support passing HTTP headers via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ For tasks that are run a number of times you can set the number using `TEST_COUN
 $ TEST_COUNT=100_000 bundle exec derailed exec perf:test
 ```
 
-## Hitting a different endpoint with `PATH_TO_HIT`
+### Hitting a different endpoint with `PATH_TO_HIT`
 
 By default tasks will hit your homepage `/`. If you want to hit a different url use `PATH_TO_HIT` for example if you wanted to go to `users/new` you can execute:
 
@@ -416,6 +416,16 @@ $ PATH_TO_HIT=http://subdomain.lvh.me:3000/users/new bundle exec derailed exec p
 ```
 
 Beware that you cannot combine a full uri with `USE_SERVER`.
+
+### Setting HTTP headers
+
+You can specify HTTP headers by setting `HTTP_<header name>` variables. Example:
+
+```
+$ HTTP_AUTHORIZATION="Basic YWRtaW46c2VjcmV0\n" \
+  HTTP_USER_AGENT="Mozilla/5.0" \
+  PATH_TO_HIT=/foo_secret bundle exec derailed exec perf:ips
+```
 
 ### Using a real web server with `USE_SERVER`
 

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -62,6 +62,22 @@ class TasksTest < ActiveSupport::TestCase
     assert_match 'Server: "webrick"', result
   end
 
+  test 'HTTP headers' do
+    env = {
+      "PATH_TO_HIT" => 'foo_secret',
+      "TEST_COUNT" => "2",
+      "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("admin:secret")}",
+      "HTTP_CACHE_CONTROL" => "no-cache"
+    }
+    result = rake "perf:test", env: env
+    assert_match 'Endpoint: "foo_secret"', result
+    assert_match 'HTTP headers: {"Authorization"=>"Basic YWRtaW46c2VjcmV0\n", "Cache-Control"=>"no-cache"}', result
+
+    env["USE_SERVER"] = "webrick"
+    result = rake "perf:test", env: env
+    assert_match 'HTTP headers: {"Authorization"=>"Basic YWRtaW46c2VjcmV0\n", "Cache-Control"=>"no-cache"}', result
+  end
+
   test 'USE_SERVER' do
     result = rake "perf:test", env: { "USE_SERVER" => 'webrick', "TEST_COUNT" => "2" }
     assert_match 'Server: "webrick"', result

--- a/test/rails_app/app/controllers/pages_controller.rb
+++ b/test/rails_app/app/controllers/pages_controller.rb
@@ -1,6 +1,11 @@
 class PagesController < ApplicationController
+  http_basic_authenticate_with name: "admin", password: "secret", only: :secret
 
   def index
+  end
+
+  def secret
+    render action: 'index'
   end
 
   private

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -53,6 +53,7 @@ Dummy::Application.routes.draw do
   root to: "pages#index"
 
   get "foo", to: "pages#index"
+  get "foo_secret", to: "pages#secret"
 
   get "authenticated", to: "authenticated#index"
 


### PR DESCRIPTION
This PR adds support to for passing HTTP headers. Both internal Rack requests and USE_SERVER is supported.

I added this while benchmarking API endpoints, which require some specific HTTP headers.