### PR TITLE
Include require_relative in core_ext/kernel_require (hopefully fixes `require_relative` monkey patch)

### DIFF
--- a/lib/derailed_benchmarks/core_ext/kernel_require.rb
+++ b/lib/derailed_benchmarks/core_ext/kernel_require.rb
@@ -16,13 +16,14 @@ module Kernel
     Kernel.require(file)
   end
 
-  # This breaks things, not sure how to fix
-  # def require_relative(file)
-  #   Kernel.require_relative(file)
-  # end
+  def require_relative(file)
+    # Kernel.require_relative(file)
+    require File.expand_path("../#{file}", caller_locations(1, 1)[0].absolute_path)
+  end
+
   class << self
     alias :original_require          :require
-    # alias :original_require_relative :require_relative
+    alias :original_require_relative :require_relative
   end
 
   # The core extension we use to measure require time of all requires

--- a/test/derailed_benchmarks/core_ext/kernel_require_test.rb
+++ b/test/derailed_benchmarks/core_ext/kernel_require_test.rb
@@ -24,6 +24,7 @@ class KernelRequireTest < ActiveSupport::TestCase
     parent    = assert_node_in_parent("parent_one.rb", TOP_REQUIRE)
     child_one = assert_node_in_parent("child_one.rb", parent)
     child_two = assert_node_in_parent("child_two.rb", parent)
+    rel_child = assert_node_in_parent("relative_child", parent)
     rse_child = assert_node_in_parent("raise_child.rb", child_two)
   end
 end

--- a/test/fixtures/require/parent_one.rb
+++ b/test/fixtures/require/parent_one.rb
@@ -4,3 +4,4 @@ class ParentOne
 end
 require File.expand_path('../child_one.rb', __FILE__)
 require File.expand_path('../child_two.rb', __FILE__)
+require_relative 'relative_child'


### PR DESCRIPTION
`Kernel.require_relative` is actually defined in the `load.c` file of ruby's source:

https://github.com/ruby/ruby/blob/b7ad549/load.c#L829-L846

Which effectively takes the current thread's callstack, determines the caller's absolute filepath from that, and then runs the same `rb_require_safe` as the C `require` function (`rb_f_require` is defined right above the `require_relative` link from above).

Because we add another layer into the stack when monkey patching `require_relative`, this doesn't work properly, and it tries to find the file in the directory that require_relative was monkey patched from, not from caller of `require_relative`.

The fix for this the monkey patching of `require_relative` was to call into the monkey patched `require` defined above it, and pass it the absolute path of the file based on the caller's absolute_path.  This is similar to the C implementation, but does have the negative side effect of probably not being as fast as it's C counter part, but I think that this will be fine, as we are measuring memory, not boot time.


Links
-----
* https://github.com/ruby/ruby/blob/b7ad549/load.c#L829-L846
* https://github.com/ruby/ruby/blob/b7ad549/load.c#L824-L827


QA
--
I have added a test to confirm that this is now working as expected, but it probably wouldn't hurt to try this on a few projects using `require_relative` before merging.  I was able to test this on a rails project where [`active_support/version`](https://github.com/rails/rails/blob/d66e783/activesupport/lib/active_support/version.rb) was the first victim when uncommenting the original implementation, and adding this fix seemed to allow things to complete after that.

That said... I have a sneaking suspicion there is some edge case sitting out there where this won't work, so I feel like a few other people trying this on different projects would be best...