### PR TITLE
Fix travis tests for Rails 5.1+

### DIFF
--- a/test/rails_app/app/controllers/application_controller.rb
+++ b/test/rails_app/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 class ApplicationController < ActionController::Base
+  if respond_to?(:before_filter) && !respond_to?(:before_action)
+    class << self
+      alias :before_action :before_filter
+    end
+  end
+
   protect_from_forgery
-  before_filter :pull_out_locale
+  before_action :pull_out_locale
 
 
   def pull_out_locale

--- a/test/rails_app/app/controllers/authenticated_controller.rb
+++ b/test/rails_app/app/controllers/authenticated_controller.rb
@@ -1,10 +1,4 @@
 class AuthenticatedController < ApplicationController
-  if respond_to?(:before_filter) && !respond_to?(:before_action)
-    class << self
-      alias :before_action :before_filter
-    end
-  end
-
   before_action :authenticate_user!
 
   def index

--- a/test/rails_app/db/migrate/20141210070547_devise_create_users.rb
+++ b/test/rails_app/db/migrate/20141210070547_devise_create_users.rb
@@ -1,4 +1,5 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+inherited_class = Rails.version < "4.2" ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
+class DeviseCreateUsers < inherited_class
   def change
     create_table(:users) do |t|
       ## Database authenticatable


### PR DESCRIPTION
Don't use `before_filter` for test rails_app since Rails changed `before_filter` to become `before_action`, so prefer using that over before_filter (since it has been removed in the [newest versions of Rails](https://github.com/rails/rails/blob/158742e/actionpack/CHANGELOG.md).

> Remove deprecated methods `skip_action_callback`, `skip_filter`, `before_filter`, `prepend_before_filter`, `skip_before_filter`, `append_before_filter`, `around_filter` `prepend_around_filter`, `skip_around_filter`, `append_around_filter`, `after_filter`, `prepend_after_filter`, `skip_after_filter` and `append_after_filter`.
> 
> Rafael Mendonça França

Also, since we are making `before_action` backwards compatible for older versions of Rails where `before_filter` was the only method available, move that alias builder to the `ApplicationController` instead of the `AuthenticatedController` which was where it lived prior.  This might not make to much sense to do since we aren't using something like [appraisal](https://github.com/thoughtbot/appraisal) in our test suite, but left it in for now.

**Update**:  A fix to the migrations was also required for this to work properly.  See the [second commit](https://github.com/schneems/derailed_benchmarks/pull/105/commits/95939192543bf2c19d1db04a014e9c621205fe81) for details.