### PR TITLE
Add status code to error on bad requests

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -102,7 +102,7 @@ namespace :perf do
 
       def call_app
         response = @app.get(PATH_TO_HIT, RACK_HTTP_HEADERS)
-        raise "Bad request: #{ response.body }" unless response.status == 200
+        raise "Bad request to #{PATH_TO_HIT}. Response status: #{response.status}, body: #{ response.body }" unless response.status == 200
         response
       end
     end


### PR DESCRIPTION
This is related to #111 and #112. This simply adds the HTTP status code that triggered the error, and makes it a bit more descriptive.