### PR TITLE
Allow warm up before recording data

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,16 @@ For tasks that are run a number of times you can set the number using `TEST_COUN
 $ TEST_COUNT=100_000 bundle exec derailed exec perf:test
 ```
 
+### Warming up your app before measuring with `WARM_COUNT`
+
+When you are measuring the long term performance of an application, especially if you're using jit you may want to let the application "warm up" without measuring this time. To allow for this you can specify `WARM_COUNT` and the application will be called that number of times before any measurements are taken.
+
+```
+$ WARM_COUNT=5_000 bundle exec derailed exec perf:test
+Warming up app: 5000 times
+# ...
+```
+
 ### Hitting a different endpoint with `PATH_TO_HIT`
 
 By default tasks will hit your homepage `/`. If you want to hit a different url use `PATH_TO_HIT` for example if you wanted to go to `users/new` you can execute:

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -62,6 +62,7 @@ namespace :perf do
       Rake::Task["perf:rack_load"].invoke
     end
 
+    WARM_COUNT  = (ENV['WARM_COUNT'] || 0).to_i
     TEST_COUNT  = (ENV['TEST_COUNT'] || ENV['CNT'] || 1_000).to_i
     PATH_TO_HIT = ENV["PATH_TO_HIT"] || ENV['ENDPOINT'] || "/"
     puts "Endpoint: #{ PATH_TO_HIT.inspect }"
@@ -105,6 +106,10 @@ namespace :perf do
         raise "Bad request: #{ response.body }" unless response.status == 200
         response
       end
+    end
+    if WARM_COUNT > 0
+      puts "Warming up app: #{WARM_COUNT} times"
+      WARM_COUNT.times { call_app }
     end
   end
 

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -51,6 +51,11 @@ class TasksTest < ActiveSupport::TestCase
     assert_match "1 requests", result
   end
 
+  test 'WARM_COUNT' do
+    result = rake "perf:test", env: { "WARM_COUNT" => 1 }
+    assert_match "Warming up app:", result
+  end
+
   test 'PATH_TO_HIT' do
     env    = { "PATH_TO_HIT" => 'foo', "TEST_COUNT" => "2" }
     result = rake "perf:test", env: env


### PR DESCRIPTION
When testing with a system that uses jit is often times desirable to “warm up” the code to test that optimizations applied after jit has run are faster.

https://twitter.com/samsaffron/status/971531146956697601


This PR allows an app to be called X times before being measured by supplying the environment variable `WARM_COUNT` with any number greater than 0. For example `WARM_COUNT=5000` will hit the app 5000 times before measurements are started. 

Default warm up is 0 so original behavior is preserved.