### PR TITLE
Fix "already initialized constant" warning

### DIFF
--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -83,7 +83,7 @@ namespace :perf do
     require 'rack/test'
     require 'rack/file'
 
-    DERAILED_APP = DerailedBenchmarks.add_auth(DERAILED_APP)
+    DERAILED_APP = DerailedBenchmarks.add_auth(Object.class_eval { remove_const(:DERAILED_APP) })
     if server = ENV["USE_SERVER"]
       @port = (3000..3900).to_a.sample
       puts "Port: #{ @port.inspect }"


### PR DESCRIPTION
I would like to remove the following warning message:

```
/home/k0kubun/src/github.com/schneems/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:86: warning: already initialized constant DERAILED_APP
/home/k0kubun/src/github.com/schneems/derailed_benchmarks/lib/derailed_benchmarks/tasks.rb:23: warning: previous definition of DERAILED_APP was here
```