### PR TITLE
Prevent undefining "require" by making it private

### DIFF
--- a/lib/derailed_benchmarks/core_ext/kernel_require.rb
+++ b/lib/derailed_benchmarks/core_ext/kernel_require.rb
@@ -9,6 +9,9 @@ ENV['CUT_OFF'] ||= "0.3"
 # Monkey patch kernel to ensure that all `require` calls call the same
 # method
 module Kernel
+
+  private
+
   alias :original_require :require
   REQUIRE_STACK = []
 


### PR DESCRIPTION
There is a code in rails in DeprecationProxy that undef methods of
deprecated object, constant, etc. But in our case we were making
"require" public so it was undefined and it was leading to a crash.

Fix: https://github.com/schneems/derailed_benchmarks/issues/128
Related:
- https://github.com/schneems/derailed_benchmarks/pull/130
- https://github.com/rails/rails/pull/36530