### PR TITLE
Add commit description and ordering to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Now you can specify two different commits to test against. Derailed will cycle b
 To run your test:
 
 ```
-$ BRANCHES_TO_TEST="7b4d80cb373e,13d6aa3a7b70" bundle exec derailed exec perf:library_branches
+$ SHAS_TO_TEST="7b4d80cb373e,13d6aa3a7b70" bundle exec derailed exec perf:library
 ```
 
 > Use a comma to seperate your branch names
@@ -419,11 +419,16 @@ Before running tests you should close all programs on your laptop, turn on a pro
 When the test is done it will output which commit "won" and by how much:
 
 ```
-Test "7b4d80cb373e" is faster than "13d6aa3a7b70" by
-  1.0062x faster or 0.6131% faster
+❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️
 
-P-value: 3.733653842080382e-05
-Is signifigant? (P-value < 0.05): true
+[7b4d80cb37] "1.8x Faster Partial Caching - Faster Cache Keys" - (10.9711965 seconds)
+  FASTER by:
+    1.0870x [older/newer]
+    8.0026% [(older - newer) / older * 100]
+[13d6aa3a7b] "Merge pull request #36284 from kamipo/fix_eager_loading_with_string_joins" - (11.9255485 seconds)
+
+P-value: 4.635595463712749e-05
+Is significant? (P-value < 0.05): true
 ```
 
 You can provide this to the Rails team along with the example app you used to benchmark (so they can independently verify if needed).

--- a/lib/derailed_benchmarks/stats_in_file.rb
+++ b/lib/derailed_benchmarks/stats_in_file.rb
@@ -11,16 +11,18 @@ module DerailedBenchmarks
   #    9.590142   0.831269  10.457801 ( 10.0)
   #    9.836019   0.837319  10.728024 ( 11.0)
   #
-  #  x = StatsForFile.new("muhfile.bench.txt")
+  #  x = StatsForFile.new(name: "muhcommit", file: "muhfile.bench.txt", desc: "I made it faster", time: Time.now)
   #  x.values  #=> [11.437769, 11.792425]
   #  x.average # => 10.5
   #  x.name    # => "muhfile"
   class StatsForFile
-    attr_reader :name, :values
+    attr_reader :name, :values, :desc, :time
 
-    def initialize(file)
-      @name = file.split("/").last.gsub(/\.bench\.txt$/, "").force_encoding("UTF-8")
+    def initialize(file:, name:, desc:, time: )
+      @name = name
       @file = Pathname.new(file)
+      @desc = desc
+      @time = time
       @values = []
       load_file!
 

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -20,17 +20,23 @@ namespace :perf do
     current_library_branch = ""
     Dir.chdir(library_dir) { current_library_branch = run!('git describe --contains --all HEAD').chomp }
 
-    puts Time.now.strftime('%Y-%m-%d-%H-%M-%s-%N')
-    out_dir = Pathname.new("tmp/library_branches/#{Time.now.strftime('%Y%m%d%h%M%s%N')}")
+    out_dir = Pathname.new("tmp/library_branches/#{Time.now.strftime('%Y-%m-%d-%H-%M-%s-%N')}")
     out_dir.mkpath
 
     branches_to_test = branch_names.each_with_object({}) {|elem, hash| hash[elem] = out_dir + "#{elem.gsub('/', ':')}.bench.txt" }
+    branch_info = {}
 
-    # Make sure the branch exists and the script runs on it
     branches_to_test.each do |branch, file|
-      Dir.chdir(library_dir) { run!("git checkout '#{branch}'") }
+      Dir.chdir(library_dir) {
+        run!("git checkout '#{branch}'")
+        description = run!("git log --oneline --format=%B -n 1 HEAD | head -n 1").strip
+        time_stamp  = run!("git log -n 1 --pretty=format:%ci").strip # https://stackoverflow.com/a/25921837/147390
+        name        = run!("git rev-parse --short HEAD").strip
+        branch_info[name] = { desc: description, time: DateTime.parse(time_stamp), file: file }
+      }
       run!("#{script}")
     end
+    puts branch_info.inspect
 
     DERAILED_SCRIPT_COUNT.times do |i|
       puts "#{i.next}/#{DERAILED_SCRIPT_COUNT}"
@@ -40,7 +46,7 @@ namespace :perf do
       end
     end
 
-    DerailedBenchmarks::StatsFromDir.new(out_dir).banner
+    DerailedBenchmarks::StatsFromDir.new(branch_info).banner
   ensure
     if library_dir && current_library_branch
       puts "Resetting git dir of #{library_dir.inspect} to #{current_library_branch.inspect}"

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -2,13 +2,14 @@ require_relative 'load_tasks'
 
 namespace :perf do
   desc "runs the same test against two different branches for statistical comparison"
-  task :library_branches do
+  task :library do
     DERAILED_SCRIPT_COUNT = (ENV["DERAILED_SCRIPT_COUNT"] ||= "100").to_i
 
     raise "test count must be at least 2, is set to #{DERAILED_SCRIPT_COUNT}" if DERAILED_SCRIPT_COUNT < 2
     script = ENV["DERAILED_SCRIPT"] || "bundle exec derailed exec perf:test"
-    branch_names = ENV.fetch("BRANCHES_TO_TEST").split(",")
+    branch_names = ENV.fetch("SHAS_TO_TEST").split(",")
 
+    # $ SHAS_TO_TEST="7b4d80cb373e,13d6aa3a7b70" bundle exec derailed exec perf:library
     if ENV["DERAILED_PATH_TO_LIBRARY"]
       library_dir = ENV["DERAILED_PATH_TO_LIBRARY"]
     else
@@ -36,7 +37,6 @@ namespace :perf do
       }
       run!("#{script}")
     end
-    puts branch_info.inspect
 
     DERAILED_SCRIPT_COUNT.times do |i|
       puts "#{i.next}/#{DERAILED_SCRIPT_COUNT}"

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -5,40 +5,96 @@ require 'test_helper'
 class StatsFromDirTest < ActiveSupport::TestCase
   test "that it works" do
     dir = fixtures_dir("stats/significant")
-    stats = DerailedBenchmarks::StatsFromDir.new(dir)
+    branch_info = {}
+    branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
+    branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), name: "winner" }
+    stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
 
-    fastest = stats.fastest
-    slowest = stats.slowest
+    newest = stats.newest
+    oldest = stats.oldest
 
-    assert fastest.average < slowest.average
+    assert newest.average < oldest.average
 
-    assert_equal "winner", fastest.name
-    assert_equal "loser", slowest.name
-
-    assert_equal "1.0062", stats.x_faster
-    assert_equal "0.6131", stats.percent_faster
+    assert_equal "winner", newest.name
+    assert_equal "loser", oldest.name
 
     assert 3.6e-05 < stats.p_value
     assert 3.8e-05 > stats.p_value
     assert_equal true, stats.significant?
+
+    assert_equal "1.0062", stats.x_faster
+    assert_equal "0.6131", stats.percent_faster
+ end
+
+  test "banner faster" do
+    dir = fixtures_dir("stats/significant")
+    branch_info = {}
+    branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
+    branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), name: "winner" }
+    stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
+    newest = stats.newest
+    oldest = stats.oldest
 
     # Test fixture for banner
     def stats.p_value
       "0.000037"
     end
 
+    def newest.average
+      10.5
+    end
+
+    def oldest.average
+      11.0
+    end
+
     expected = <<-EOM
-Test "winner" is faster than "loser" by
-  1.0062x faster or 0.6131% faster
+[winner] "I am the new commit" - (10.5 seconds)
+  FASTER by:
+    1.0476x [older/newer]
+    4.5455% [(older - newer) / older * 100]
+[loser] "Old commit" - (11.0 seconds)
 
 P-value: 0.000037
-Is signifigant? (P-value < 0.05): true
+Is significant? (P-value < 0.05): true
 EOM
 
     actual = StringIO.new
-    actual.flush
     stats.banner(actual)
 
+    puts actual.string
+    assert_match expected, actual.string
+  end
+
+  test "banner slower" do
+    dir = fixtures_dir("stats/significant")
+    branch_info = {}
+    branch_info["loser"]  = { desc: "I am the new commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
+    branch_info["winner"] = { desc: "Old commit", time: Time.now - 10, file: dir.join("winner.bench.txt"), name: "winner" }
+    stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
+    newest = stats.newest
+    oldest = stats.oldest
+
+    def oldest.average
+      10.5
+    end
+
+    def newest.average
+      11.0
+    end
+
+    expected = <<-EOM
+[loser] "I am the new commit" - (11.0 seconds)
+  SLOWER by:
+    0.9545x [older/newer]
+    -4.7619% [(older - newer) / older * 100]
+[winner] "Old commit" - (10.5 seconds)
+EOM
+
+    actual = StringIO.new
+    stats.banner(actual)
+
+    puts actual.string
     assert_match expected, actual.string
   end
 end

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -62,7 +62,6 @@ EOM
     actual = StringIO.new
     stats.banner(actual)
 
-    puts actual.string
     assert_match expected, actual.string
   end
 
@@ -94,7 +93,6 @@ EOM
     actual = StringIO.new
     stats.banner(actual)
 
-    puts actual.string
     assert_match expected, actual.string
   end
 end

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -30,8 +30,8 @@ class TasksTest < ActiveSupport::TestCase
   test 'library_branches' do
     skip unless ENV['USING_RAILS_GIT']
 
-    env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2, "BRANCHES_TO_TEST" => "3054e1d584e7eca110c69a1f8423f2e0866abbf9,80f989aecece1a2b1830e9c953e5887421b52d3c"}
-    rake "perf:library_branches", { env: env }
+    env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2, "SHAS_TO_TEST" => "3054e1d584e7eca110c69a1f8423f2e0866abbf9,80f989aecece1a2b1830e9c953e5887421b52d3c"}
+    rake "perf:library", { env: env }
   end
 
   test 'hitting authenticated devise apps' do


### PR DESCRIPTION
There were some problems to the old formatting of the library comparison
output. The x faster and % faster were confusing because it wasn't clear
how they were derived. Also it was not clear which commit SHA belonged
to which values.

In this updated value we give the formulas for the values that are being
shown as well. The latest commit is always first and the value will show
either SLOWER or FASTER based on actual values. Finally we're including
the git first line description to make it clearer which commit is which.

New output looks like this:

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

[7b4d80cb37] "1.8x Faster Partial Caching - Faster Cache Keys" - (10.9711965 seconds)
  FASTER by:
    1.0870x [older/newer]
    8.0026% [(older - newer) / older * 100]
[13d6aa3a7b] "Merge pull request #36284 from kamipo/fix_eager_loading_with_string_joins" - (11.9255485 seconds)

P-value: 4.635595463712749e-05
Is significant? (P-value < 0.05): true
```