### PR TITLE
Default perf:library to last two commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ To run your test:
 $ SHAS_TO_TEST="7b4d80cb373e,13d6aa3a7b70" bundle exec derailed exec perf:library
 ```
 
-> Use a comma to seperate your branch names
+> Use a comma to seperate your branch names with the `SHAS_TO_TEST` env var, or omit the env var to use the last 2 git commits
 
 Derailed will automatically find where you've installed Rails and switch between the branches for you between the tests.
 

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -7,7 +7,6 @@ namespace :perf do
 
     raise "test count must be at least 2, is set to #{DERAILED_SCRIPT_COUNT}" if DERAILED_SCRIPT_COUNT < 2
     script = ENV["DERAILED_SCRIPT"] || "bundle exec derailed exec perf:test"
-    branch_names = ENV.fetch("SHAS_TO_TEST").split(",")
 
     # $ SHAS_TO_TEST="7b4d80cb373e,13d6aa3a7b70" bundle exec derailed exec perf:library
     if ENV["DERAILED_PATH_TO_LIBRARY"]
@@ -17,6 +16,13 @@ namespace :perf do
     end
 
     raise "Must be a path with a .git directory '#{library_dir}'" unless File.exist?(File.join(library_dir, ".git"))
+
+    if ENV["SHAS_TO_TEST"]
+      branch_names = ENV.fetch("SHAS_TO_TEST").split(",")
+    else
+      branch_names = []
+      Dir.chdir(library_dir) { branch_names = run!('git log --format="%H" -n 2').chomp.split($INPUT_RECORD_SEPARATOR) }
+    end
 
     current_library_branch = ""
     Dir.chdir(library_dir) { current_library_branch = run!('git describe --contains --all HEAD').chomp }


### PR DESCRIPTION
The most common case will be to test the last to git SHAs, so when the
env var does not specify specific commits, we will default to the last
two in the git repo.