### PR TITLE
Better defaults for perf:library

### DIFF
--- a/gemfiles/rails_git.gemfile
+++ b/gemfiles/rails_git.gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# $ BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:29
+# $ BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:30
 
 source "https://rubygems.org"
 

--- a/lib/derailed_benchmarks/stats_in_file.rb
+++ b/lib/derailed_benchmarks/stats_in_file.rb
@@ -18,12 +18,16 @@ module DerailedBenchmarks
   class StatsForFile
     attr_reader :name, :values, :desc, :time
 
-    def initialize(file:, name:, desc:, time: )
-      @name = name
+    def initialize(file:, name:, desc: "", time: )
       @file = Pathname.new(file)
+      FileUtils.touch(@file)
+
+      @name = name
       @desc = desc
       @time = time
-      @values = []
+    end
+
+    def call
       load_file!
 
       @average = values.inject(:+) / values.length
@@ -33,13 +37,14 @@ module DerailedBenchmarks
       @average.to_f
     end
 
-    def load_file!
+    private def load_file!
+      @values = []
       @file.each_line do |line|
         line.match(/\( +(\d+\.\d+)\)/)
         begin
           values << BigDecimal($1)
         rescue => e
-          raise e, "Problem with file #{file_name.inspect}:\n#{file_contents}\n#{e.message}"
+          raise e, "Problem with file #{@file.inspect}:\n#{@file.read}\n#{e.message}"
         end
       end
       values.freeze

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -95,4 +95,10 @@ EOM
 
     assert_match expected, actual.string
   end
+
+  test "stats from samples with slightly different sizes" do
+    stats = DerailedBenchmarks::StatsFromDir.new({})
+    out = stats.students_t_test([100,101,102], [1,3])
+    assert out[:alternative]
+  end
 end

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -8,7 +8,7 @@ class StatsFromDirTest < ActiveSupport::TestCase
     branch_info = {}
     branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
     branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), name: "winner" }
-    stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
+    stats = DerailedBenchmarks::StatsFromDir.new(branch_info).call
 
     newest = stats.newest
     oldest = stats.oldest
@@ -31,7 +31,7 @@ class StatsFromDirTest < ActiveSupport::TestCase
     branch_info = {}
     branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
     branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), name: "winner" }
-    stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
+    stats = DerailedBenchmarks::StatsFromDir.new(branch_info).call
     newest = stats.newest
     oldest = stats.oldest
 
@@ -54,9 +54,6 @@ class StatsFromDirTest < ActiveSupport::TestCase
     1.0476x [older/newer]
     4.5455% [(older - newer) / older * 100]
 [loser] "Old commit" - (11.0 seconds)
-
-P-value: 0.000037
-Is significant? (P-value < 0.05): true
 EOM
 
     actual = StringIO.new
@@ -70,7 +67,7 @@ EOM
     branch_info = {}
     branch_info["loser"]  = { desc: "I am the new commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
     branch_info["winner"] = { desc: "Old commit", time: Time.now - 10, file: dir.join("winner.bench.txt"), name: "winner" }
-    stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
+    stats = DerailedBenchmarks::StatsFromDir.new(branch_info).call
     newest = stats.newest
     oldest = stats.oldest
 

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -31,7 +31,7 @@ class TasksTest < ActiveSupport::TestCase
     skip unless ENV['USING_RAILS_GIT']
 
     env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2, "SHAS_TO_TEST" => "3054e1d584e7eca110c69a1f8423f2e0866abbf9,80f989aecece1a2b1830e9c953e5887421b52d3c"}
-    rake "perf:library", { env: env }
+    puts rake "perf:library", { env: env }
   end
 
   test 'hitting authenticated devise apps' do


### PR DESCRIPTION
By default perf:library will not stop when it detects 10 runs that are
statistically significant. This provides an average that is not as
accurate, but decreases the time to run a benchmark from 60+ minutes per
run to as little as 3 minutes and results are roughly comparable. This
setting can also be tuned so that all benchmark iterations are forced to
run.

In addition, one SHA can be specified instead of 2. When this is
provided then derailed will assume you want this SHA run against the
most recent commit present. This could be useful if you are trying out
different changes on a branch and want to always compare the same
baseline to the latest commit in your branch.