### PR TITLE
Allow `require_relative` to accept absolute paths

### DIFF
--- a/lib/derailed_benchmarks/core_ext/kernel_require.rb
+++ b/lib/derailed_benchmarks/core_ext/kernel_require.rb
@@ -22,8 +22,10 @@ module Kernel
   end
 
   def require_relative(file)
-    # Kernel.require_relative(file)
-    require File.expand_path("../#{file}", caller_locations(1, 1)[0].absolute_path)
+    root = Pathname.new(caller_locations(1, 1)[0].absolute_path).realpath.dirname
+    path = Pathname.new(file)
+    path = Pathname.new(File.expand_path(file, root)) if path.relative?
+    require path.to_s
   end
 
   class << self

--- a/test/derailed_benchmarks/core_ext/kernel_require_test.rb
+++ b/test/derailed_benchmarks/core_ext/kernel_require_test.rb
@@ -27,6 +27,7 @@ class KernelRequireTest < ActiveSupport::TestCase
     assert_node_in_parent("child_one.rb", parent)
     child_two = assert_node_in_parent("child_two.rb", parent)
     assert_node_in_parent("relative_child", parent)
+    assert_node_in_parent("relative_child_two", parent)
     assert_node_in_parent("raise_child.rb", child_two)
   end
 end

--- a/test/fixtures/require/parent_one.rb
+++ b/test/fixtures/require/parent_one.rb
@@ -5,3 +5,4 @@ end
 require File.expand_path('../child_one.rb', __FILE__)
 require File.expand_path('../child_two.rb', __FILE__)
 require_relative 'relative_child'
+require_relative File.expand_path('relative_child_two', __dir__)

--- a/test/fixtures/require/relative_child_two.rb
+++ b/test/fixtures/require/relative_child_two.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RelativeChildTwo
+end


### PR DESCRIPTION
Ruby's `require_relative` [converts paths to absolute paths][1] before
calling `require`. This conversion effectively means that you can pass
an absolute path to `require_relative` and have it load the file
correctly, as if it were a relative path.

This is an idiosyncrasy of Ruby that doesn't match the semantics of the
method. However, some libraries, like [grpc][2], rely on the
idiosyncrasy to load files. Because Derailed's implementation doesn't
conform to this idiosyncrasy, it is unable to work when such libraries
exist in a project.

This change makes Derailed's implementation of `require_relative` behave
more closely to the implementation in Ruby. By making this change, you
can use Derailed with any offending gem.

[1]: https://github.com/ruby/ruby/blob/v2_6_3/load.c#L832-L841
[2]: https://github.com/grpc/grpc/blob/v1.22.0/src/ruby/lib/grpc/grpc.rb#L20