### PR TITLE
Allow config of `Benchmark.ips` via env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # A Log of Changes!
 
+- Allow configuration of `perf:ips` benchmark.
+
 ## 1.4.0
 
 - Fix bug with `require_relative` [#142](https://github.com/schneems/derailed_benchmarks/pull/142)

--- a/README.md
+++ b/README.md
@@ -388,6 +388,15 @@ $ bundle exec derailed exec perf:test
 
 But I wouldn't, benchmark-ips is a better measure.
 
+### Configuring `benchmark-ips`
+
+The `benchmark-ips` gem allows for a number of test run customizations, and `derailed_benchmarks` exposes a few of them via environment variables.
+
+- `IPS_WARMUP`: number of seconds spent warming up the app, defaullt is `2`
+- `IPS_TIME`: number of seconds to run ips benchmark for after warm up, defaullt is `5`
+- `IPS_SUITE`: custom suite to use to run test
+- `IPS_ITERATIONS`: number of times to run the test, displaying that last result, defaullt is `1`
+
 ## I made a patch to to Rails how can I tell if it made my Rails app faster and test for statistical significance
 
 When you're trying to submit a performance patch to rails/rails then they'll likely ask you for a benchmark. While you can sometimes provide a microbenchmark, a real world full stack request/response test is the gold standard.

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -172,6 +172,9 @@ namespace :perf do
     require 'benchmark/ips'
 
     Benchmark.ips do |x|
+      x.warmup = Float(ENV["WARMUP"] || 2)
+      x.time = Float(ENV["TIME"] || 5)
+
       x.report("ips") { call_app }
     end
   end

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -172,8 +172,10 @@ namespace :perf do
     require 'benchmark/ips'
 
     Benchmark.ips do |x|
-      x.warmup = Float(ENV["WARMUP"] || 2)
-      x.time = Float(ENV["TIME"] || 5)
+      x.warmup = Float(ENV["IPS_WARMUP"] || 2)
+      x.time = Float(ENV["IPS_TIME"] || 5)
+      x.suite = ENV["IPS_SUITE"] if ENV["IPS_SUITE"]
+      x.iterations = Integer(ENV["IPS_ITERATIONS"] || 1)
 
       x.report("ips") { call_app }
     end


### PR DESCRIPTION
I was finding that 5 seconds was not long enough for me to feel comfortable with the results with my `perf:ips`, so I added the ability to configure the  `Benchmark.ips` test run via environment variables. I prefixed each of them with `IPS_*` since they we specific only to this test.

I didn't immediately see a place to add tests for this, but if you like the PR and can point me to it. I'll add them.