### PR TITLE
Guard, and fix single sha perf:library tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # A Log of Changes!
 
+- Fix case in perf:library where the same SHA could be tested against itself (https://github.com/schneems/derailed_benchmarks/pull/153)
+
 ## 1.4.1
 
 - Rake dependency now allows for Rake 13 (https://github.com/schneems/derailed_benchmarks/pull/151)

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -65,9 +65,7 @@ namespace :perf do
     puts
     puts
 
-    branch_info.each do |short_sha, hash|
-      puts "Testing: #{short_sha}: #{hash[:desc]}"
-    end
+    raise "SHAs to test must be different" if branch_info.length == 1
 
     stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
     ENV["DERAILED_STOP_VALID_COUNT"] ||= "50"
@@ -86,7 +84,7 @@ namespace :perf do
 
   ensure
     if library_dir && current_library_branch
-      puts "Resetting git dir of #{library_dir.inspect} to #{current_library_branch.inspect}"
+      puts "Resetting git dir of '#{library_dir.to_s}' to #{current_library_branch.inspect}"
       Dir.chdir(library_dir) do
         run!("git checkout '#{current_library_branch}'")
       end

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -23,10 +23,13 @@ namespace :perf do
     branch_names = ENV.fetch("SHAS_TO_TEST").split(",") if ENV["SHAS_TO_TEST"]
     if branch_names.length < 2
       Dir.chdir(library_dir) do
-        branches = run!('git log --format="%H" -n 2').chomp.split($INPUT_RECORD_SEPARATOR)
+        run!("git checkout '#{branch_names.first}'") unless branch_names.empty?
+
+        branches = run!('git log --format="%H" -n 2').chomp.split($/)
         if branch_names.empty?
           branch_names = branches
         else
+          branches.shift
           branch_names << branches.shift
         end
       end


### PR DESCRIPTION
When using perf:library there was a bug that would result in the same sha being tested twice for instance if you ran:

```
$ SHAS_TO_TEST='schneems/keymaster-more-compat-correct' bundle exec derailed exec perf:library
```

Then it would incorrectly default to the same SHA. This PR fixes that behavior, it also detects this failure mode and raises an error if it happens somehow (perhaps the user accidentally puts it in twice somehow).

In addition there's a nice litte testing output that advertises which sha and description you're testing before you execute the tests:

```
Testing 1: fe60c15579: Preserve existing interfaces for smaller diff
Testing 2: 430579e40b: 1.8x Faster Partial Caching - Faster Cache Keys
```