### PR TITLE
Generalizing to the current directory to support all libraries, not just rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## master (unreleased)
+## 1.4.5
+- Added the `perf:app` command to compare commits within the same application.
 
 ## 1.4.4
 

--- a/README.md
+++ b/README.md
@@ -415,13 +415,23 @@ or point it at your local copy:
 gem 'rails', path: "<path/to/your/local/copy/rails>"
 ```
 
-To run your test:
+To run your tests within the context of your current app/repo:
+
+```
+$ bundle exec derailed exec perf:app
+```
+
+This will automatically test the two latest commits of your library/current directory.
+
+If you'd like to test the Rails library instead, make sure that `ENV[DERAILED_PATH_TO_LIBRARY]` is unset.
 
 ```
 $ bundle exec derailed exec perf:library
 ```
 
-This will automatically test the two latest commits of Rails (or the library you've specified). If you would like to compare against different SHAs you can manually specify them:
+This will automatically test the two latest commits of Rails.
+
+If you would also like to compare against different SHAs you can manually specify them:
 
 ```
 $ SHAS_TO_TEST="7b4d80cb373e,13d6aa3a7b70" bundle exec derailed exec perf:library

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -1,6 +1,12 @@
 require_relative 'load_tasks'
 
 namespace :perf do
+  desc "runs the performance test against two most recent commits of the current app"
+  task :app do
+    ENV["DERAILED_PATH_TO_LIBRARY"] = '.'
+    Rake::Task["perf:library"].invoke
+  end
+
   desc "runs the same test against two different branches for statistical comparison"
   task :library do
     begin

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -13,6 +13,13 @@ class TasksTest < ActiveSupport::TestCase
     FileUtils.remove_entry_secure(rails_app_path('tmp'))
   end
 
+  def run!(cmd)
+    puts "Running: #{cmd}"
+    out = `#{cmd}`
+    raise "Could not run #{cmd}, output: #{out}" unless $?.success?
+    out
+  end
+
   def rake(cmd, options = {})
     assert_success = options.key?(:assert_success) ? options[:assert_success] : true
     env             = options[:env]           || {}
@@ -53,6 +60,13 @@ class TasksTest < ActiveSupport::TestCase
 
   test 'test' do
     rake "perf:test"
+  end
+
+  test 'app' do
+    skip unless ENV['USING_RAILS_GIT']
+    run!("cd #{rails_app_path} && git init . && git add . && git commit -m first && git commit --allow-empty -m second")
+    env = { "TEST_COUNT" => 10, "DERAILED_SCRIPT_COUNT" => 2 }
+    puts rake "perf:app", { env: env }
   end
 
   test 'TEST_COUNT' do


### PR DESCRIPTION
Currently, this only supports libraries if the user inputs the env variable. Now, we can take the current directory and run the performance tests comparing the two previous commits there.

CC: @schneems 