### PR TITLE
[changelog skip] Fix bug and add extra output to `perf:library`

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Use a comma to seperate your branch names with the `SHAS_TO_TEST` env var, or om
 
 If you only include one SHA, then derailed will grab the latest commit and compare it to that SHA.
 
-These tests might take a along time to run so the output is stored on disk incase you want to see them in the future, they're at `tmp/library_branches/<timestamp>` and labeled with the same names as your commits.
+These tests might take a along time to run so the output is stored on disk incase you want to see them in the future, they're at `tmp/compare_branches/<timestamp>` and labeled with the same names as your commits.
 
 When the test is done it will output which commit "won" and by how much:
 

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -93,10 +93,11 @@ namespace :perf do
         end
       end
 
+      puts "Log dir: out_dir.inspect"
       stats.call.banner if stats
     end
    end
-  
+
 
   desc "hits the url TEST_COUNT times"
   task :test => [:setup] do

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -39,7 +39,7 @@ namespace :perf do
       current_library_branch = ""
       Dir.chdir(library_dir) { current_library_branch = run!('git describe --contains --all HEAD').chomp }
 
-      out_dir = Pathname.new("tmp/library_branches/#{Time.now.strftime('%Y-%m-%d-%H-%M-%s-%N')}")
+      out_dir = Pathname.new("tmp/compare_branches/#{Time.now.strftime('%Y-%m-%d-%H-%M-%s-%N')}")
       out_dir.mkpath
 
       branches_to_test = branch_names.each_with_object({}) {|elem, hash| hash[elem] = out_dir + "#{elem.gsub('/', ':')}.bench.txt" }

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -96,7 +96,7 @@ namespace :perf do
       puts "Log dir: out_dir.inspect"
       stats.call.banner if stats
     end
-   end
+  end
 
 
   desc "hits the url TEST_COUNT times"

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -93,11 +93,18 @@ namespace :perf do
         end
       end
 
-      puts "Log dir: out_dir.inspect"
-      stats.call.banner if stats
+      if stats
+        stats.call.banner
+
+        result_file = out_dir + "results.txt"
+        File.open(result_file, "w") do |f|
+          stats.banner(f)
+        end
+
+        puts "Output: #{result_file.to_s}"
+      end
     end
   end
-
 
   desc "hits the url TEST_COUNT times"
   task :test => [:setup] do


### PR DESCRIPTION
While using `perf:library` I found that I wanted to know what directory a given test run was stored in. So now the output looks like this:

```
👎👎👎(NOT Statistically Significant) 👎👎👎

[3054e1d584] "Merge pull request #36506 from kamipo/group_by_with_order_by_virtual_count_attribute" - (0.017138 seconds)
  SLOWER by:
    0.9702x [older/newer]
    -3.0764% [(older - newer) / older * 100]
[80f989aece] "Remove duplicated attribute alias resolution in `_select!`" - (0.0166265 seconds)

Iterations per sample: 10
Samples: 2

Test type: Kolmogorov Smirnov
Is significant? (max > critical): false
D max: 0.5
D critical: 1.2238734153404083

Output: tmp/compare_branches/2019-12-16-21-20-1576552858-200576000/results.txt
```

> Note the file in the bottom which has the directory name `tmp/compare_branches/2019-12-16-21-20-1576552858-200576000`

I also found that in addition to the raw results I wanted the calculations (which was faster, by how much, and was it statistically significant or not). So in addition to printing the banner to the output, i'm now also writing it to the `results` file which you see in the output string.

In the process of adding these features, i found tests were failing 

```
$ BUNDLE_GEMFILE="$(pwd)/gemfiles/rails_git.gemfile" bundle exec m test/integration/tasks_test.rb:30
```

Which showed that the issue is `stats.banner.call` should have been `stats.call.banner` so I think this PR fixes the test suite.