### PR TITLE
Use median over average

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master (unreleased)
 
+## 1.4.3
+
+- perf:library now uses median instead of average (https://github.com/schneems/derailed_benchmarks/pull/160)
+
 ## 1.4.2
 
 - Fixed syntax error that resulted in ensure end error inside tasks.rb for older rubies (https://github.com/schneems/derailed_benchmarks/pull/155)

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -66,15 +66,27 @@ module DerailedBenchmarks
     end
 
     def x_faster
-      FORMAT % (oldest.average/newest.average).to_f
+      (oldest.median/newest.median).to_f
+    end
+
+    def faster?
+      newest.median < oldest.median
     end
 
     def percent_faster
-      FORMAT % (((oldest.average - newest.average) / oldest.average).to_f  * 100)
+      (((oldest.median - newest.median) / oldest.median).to_f  * 100)
     end
 
     def change_direction
-      newest.average < oldest.average ? "FASTER" : "SLOWER"
+      if faster?
+        "FASTER 🚀🚀🚀"
+      else
+        "SLOWER 🐢🐢🐢"
+      end
+    end
+
+    def align
+      " " * (("%i" % percent_faster).length - ("%i" % x_faster).length)
     end
 
     def banner(io = Kernel)
@@ -85,11 +97,11 @@ module DerailedBenchmarks
         io.puts "👎👎👎(NOT Statistically Significant) 👎👎👎"
       end
       io.puts
-      io.puts "[#{newest.name}] #{newest.desc.inspect} - (#{newest.average} seconds)"
+      io.puts "[#{newest.name}] #{newest.desc.inspect} - (#{newest.median} seconds)"
       io.puts "  #{change_direction} by:"
-      io.puts "    #{x_faster}x [older/newer]"
-      io.puts "    #{percent_faster}\% [(older - newer) / older * 100]"
-      io.puts "[#{oldest.name}] #{oldest.desc.inspect} - (#{oldest.average} seconds)"
+      io.puts "    #{align}#{FORMAT % x_faster}x [older/newer]"
+      io.puts "    #{FORMAT % percent_faster}\% [(older - newer) / older * 100]"
+      io.puts "[#{oldest.name}] #{oldest.desc.inspect} - (#{oldest.median} seconds)"
       io.puts
       io.puts "Iterations per sample: #{ENV["TEST_COUNT"]}"
       io.puts "Samples: #{newest.values.length}"

--- a/lib/derailed_benchmarks/stats_in_file.rb
+++ b/lib/derailed_benchmarks/stats_in_file.rb
@@ -30,7 +30,12 @@ module DerailedBenchmarks
     def call
       load_file!
 
+      @median = (values[(values.length - 1) / 2] + values[values.length/ 2]) / 2.0
       @average = values.inject(:+) / values.length
+    end
+
+    def median
+      @median.to_f
     end
 
     def average
@@ -47,6 +52,8 @@ module DerailedBenchmarks
           raise e, "Problem with file #{@file.inspect}:\n#{@file.read}\n#{e.message}"
         end
       end
+
+      values.sort!
       values.freeze
     end
   end

--- a/lib/derailed_benchmarks/version.rb
+++ b/lib/derailed_benchmarks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DerailedBenchmarks
-  VERSION = "1.4.2"
+  VERSION = "1.4.3"
 end

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -22,8 +22,11 @@ class StatsFromDirTest < ActiveSupport::TestCase
     assert_in_delta 0.1730818382602285, stats.d_critical, 0.00001
     assert_equal true, stats.significant?
 
-    assert_equal "1.0062", stats.x_faster
-    assert_equal "0.6131", stats.percent_faster
+    format = DerailedBenchmarks::StatsFromDir::FORMAT
+    assert_equal "1.0062", format % stats.x_faster
+    assert_equal "0.6147", format % stats.percent_faster
+
+    assert_equal "11.3844", format % newest.median
  end
 
   test "banner faster" do
@@ -44,17 +47,17 @@ class StatsFromDirTest < ActiveSupport::TestCase
       "0.001"
     end
 
-    def newest.average
+    def newest.median
       10.5
     end
 
-    def oldest.average
+    def oldest.median
       11.0
     end
 
-    expected = <<-EOM
+    expected = <<~EOM
 [winner] "I am the new commit" - (10.5 seconds)
-  FASTER by:
+  FASTER 🚀🚀🚀 by:
     1.0476x [older/newer]
     4.5455% [(older - newer) / older * 100]
 [loser] "Old commit" - (11.0 seconds)
@@ -75,18 +78,18 @@ EOM
     newest = stats.newest
     oldest = stats.oldest
 
-    def oldest.average
+    def oldest.median
       10.5
     end
 
-    def newest.average
+    def newest.median
       11.0
     end
 
-    expected = <<-EOM
+    expected = <<~EOM
 [loser] "I am the new commit" - (11.0 seconds)
-  SLOWER by:
-    0.9545x [older/newer]
+  SLOWER 🐢🐢🐢 by:
+     0.9545x [older/newer]
     -4.7619% [(older - newer) / older * 100]
 [winner] "Old commit" - (10.5 seconds)
 EOM


### PR DESCRIPTION
Since we don't know the shape of the distribution we're dealing with, it's better to use the median value rather than the average for comparisons

Also adding some alignment so that 

```
[3054e1d584] "Merge pull request #36506 from kamipo/group_by_with_order_by_virtual_count_attribute" - (0.016381 seconds)
  SLOWER by:
    0.9697x [older/newer]
    -3.1224% [(older - newer) / older * 100]
```

Will become:

```
[3054e1d584] "Merge pull request #36506 from kamipo/group_by_with_order_by_virtual_count_attribute" - (0.016381 seconds)
  SLOWER by:
     0.9697x [older/newer]
    -3.1224% [(older - newer) / older * 100]
```

(Minor, but it was really bugging me)

Also added emojis for faster and slower:

```
  SLOWER 🐢🐢🐢 by:
```

Which helps to visually distinguish results.