### PR TITLE
Don't use statistical significance as a stopping condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Change default, `perf:library` tests do not stop automatically any more (https://github.com/schneems/derailed_benchmarks/pull/164)
+
 ## 1.4.4
 
 - Fix alignment of deicmals in output (https://github.com/schneems/derailed_benchmarks/pull/161)

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ You can use this to test changes in other libraries that aren't rails, you just 
 
 > To get the best results before running tests you should close all programs on your laptop, turn on a program to prevent your laptop from going to sleep (or increase your sleep timer). Make sure it's plugged into a power outlet and  go grab a cup of coffee. If you do anything on your laptop while this test is running you risk the chance of skewing your results.
 
-By default derailed will stop once statistical signficance has been detected, you can tune this behavior by setting `DERAILED_STOP_VALID_COUNT` env var. Setting this to a positive number, will increase the number of iterations required that are detected to be statistically significant. For example setting it to 100 might result in 120 runs if it takes 20 runs to detect significance. Generally the more runs you have, the more accurate your averages will be. You can disable this all together by setting `DERAILED_STOP_VALID_COUNT=0` which will force derailed to run all iterations.
+As the test is executing, intermediate results will be printed every 50 iterations.
 
 ## Environment Variables
 

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -71,18 +71,20 @@ namespace :perf do
 
       raise "SHAs to test must be different" if branch_info.length == 1
       stats = DerailedBenchmarks::StatsFromDir.new(branch_info)
-      ENV["DERAILED_STOP_VALID_COUNT"] ||= "50"
-      stop_valid_count = Integer(ENV["DERAILED_STOP_VALID_COUNT"])
+      puts "Env var no longer has any affect DERAILED_STOP_VALID_COUNT" if ENV["DERAILED_STOP_VALID_COUNT"]
 
-      times_significant = 0
       DERAILED_SCRIPT_COUNT.times do |i|
         puts "Sample: #{i.next}/#{DERAILED_SCRIPT_COUNT} iterations per sample: #{ENV['TEST_COUNT']}"
         branches_to_test.each do |branch, file|
           Dir.chdir(library_dir) { run!("git checkout '#{branch}'") }
           run!(" #{script} 2>&1 | tail -n 1 >> '#{file}'")
         end
-        times_significant += 1 if i >= 2 && stats.call.significant?
-        break if stop_valid_count != 0 && times_significant == stop_valid_count
+
+        if (i % 50).zero?
+          puts "Intermediate result"
+          stats.call.banner
+          puts "Continuing execution"
+        end
       end
 
     ensure


### PR DESCRIPTION
The goal of adding the statistical significane check was to determine if it was "safe" to stop early, but this method of constantly checking for significance and then stopping produces less than stellar results. It's better to default to running the full test.

As a compromise the intermediate results are also output so if someone wants to use this as a quick and dirty guide for if they're on the right track or not, they can but they should know it might not hold up to scrutiny.