### PR TITLE
Check multiple confidence intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
 
+- Test `perf:library` results against 99% confidence interval in addition to 95% (https://github.com/schneems/derailed_benchmarks/pull/165)
 - Change default, `perf:library` tests do not stop automatically any more (https://github.com/schneems/derailed_benchmarks/pull/164)
 
 ## 1.4.4

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -19,7 +19,7 @@ class StatsFromDirTest < ActiveSupport::TestCase
     assert_equal "loser", oldest.name
 
     assert_in_delta 0.26, stats.d_max, 0.01
-    assert_in_delta 0.1730818382602285, stats.d_critical, 0.00001
+    assert_in_delta 0.2145966026289347, stats.d_critical, 0.00001
     assert_equal true, stats.significant?
 
     format = DerailedBenchmarks::StatsFromDir::FORMAT


### PR DESCRIPTION
I want to know if a patch stands up to a more rigorous statistical check. Instead of forcing the user to specify what confidence interval they want, we default to 95% then if it passes we try to check again at 99%. 

If the 99% check fails then we rely on the 95% check, but note the different confidence interval in the output.