### PR TITLE
Support Rails 6.x and bump thor requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Allow Rails < 7 and 1.0 <= Thor < 2 (https://github.com/schneems/derailed_benchmarks/pull/168)
+
 ## 1.5.0
 
 - Test `perf:library` results against 99% confidence interval in addition to 95% (https://github.com/schneems/derailed_benchmarks/pull/165)

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -28,12 +28,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency "benchmark-ips",   "~> 2"
   gem.add_dependency "rack",            ">= 1"
   gem.add_dependency "rake",            "> 10", "< 14"
-  gem.add_dependency "thor",            "~> 0.19"
+  gem.add_dependency "thor",            ">= 0.19", "< 2"
   gem.add_dependency "ruby-statistics", ">= 2.1"
 
   gem.add_development_dependency "capybara",  "~> 2"
   gem.add_development_dependency "m"
-  gem.add_development_dependency "rails",     "> 3", "<= 6"
+  gem.add_development_dependency "rails",     "> 3", "<= 7"
   gem.add_development_dependency "devise",    "> 3", "< 6"
   gem.add_development_dependency "appraisal", "2.2.0"
 end


### PR DESCRIPTION
bump rails requirement for < 7 and rails 6.1.0.alpha now requires thor ~> 1.0.