### PR TITLE
Add histogram to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
 
+- Add histogram support to `perf:library` (https://github.com/schneems/derailed_benchmarks/pull/169)
 - Fix bug with `Kernel#require` patch when Zeitwerk is enabled (https://github.com/schneems/derailed_benchmarks/pull/170)
 
 ## 1.6.0

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "thor",            ">= 0.19", "< 2"
   gem.add_dependency "ruby-statistics", ">= 2.1"
   gem.add_dependency "unicode_plot",    ">= 0.0.4", "< 1.0.0"
+  gem.add_dependency "mini_histogram",    "~> 0"
 
   gem.add_development_dependency "capybara",  "~> 2"
   gem.add_development_dependency "m"

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
   gem.add_dependency "ruby-statistics", ">= 2.1"
+  gem.add_dependency "unicode_plot",    ">= 0.0.4", "< 1.0.0"
 
   gem.add_development_dependency "capybara",  "~> 2"
   gem.add_development_dependency "m"

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -2,6 +2,8 @@
 
 require 'bigdecimal'
 require 'statistics'
+require 'unicode_plot'
+require 'stringio'
 
 module DerailedBenchmarks
   # A class used to read several benchmark files
@@ -100,7 +102,17 @@ module DerailedBenchmarks
       " " * (percent_faster.to_s.index(".") - x_faster.to_s.index("."))
     end
 
-    def banner(io = Kernel)
+    def histogram(io = $stdout)
+      [newest, oldest].each do |report|
+        plot = UnicodePlot.histogram(report.values, title: "\nHistogram - [#{report.name}] #{report.desc.inspect}")
+        plot.render(io)
+        io.puts
+      end
+
+      io.puts
+    end
+
+    def banner(io = $stdout)
       io.puts
       if significant?
         io.puts "❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️"
@@ -122,6 +134,9 @@ module DerailedBenchmarks
       io.puts "Is significant? (max > critical): #{significant?}"
       io.puts "D critical: #{d_critical}"
       io.puts "D max: #{d_max}"
+
+      histogram(io)
+
       io.puts
     end
   end

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -106,7 +106,7 @@ module DerailedBenchmarks
       [newest, oldest].each do |report|
         plot = UnicodePlot.histogram(
           report.values,
-          title: "\nHistogram - [#{report.name}] #{report.desc.inspect}",
+          title: "\n#{' ' * 18 }Histogram - [#{report.name}] #{report.desc.inspect}",
           ylabel: "Time (seconds)",
           xlabel: "# of runs in range"
         )

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -104,7 +104,12 @@ module DerailedBenchmarks
 
     def histogram(io = $stdout)
       [newest, oldest].each do |report|
-        plot = UnicodePlot.histogram(report.values, title: "\nHistogram - [#{report.name}] #{report.desc.inspect}")
+        plot = UnicodePlot.histogram(
+          report.values,
+          title: "\nHistogram - [#{report.name}] #{report.desc.inspect}",
+          ylabel: "Time (seconds)",
+          xlabel: "# of runs in range"
+        )
         plot.render(io)
         io.puts
       end

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -4,6 +4,7 @@ require 'bigdecimal'
 require 'statistics'
 require 'unicode_plot'
 require 'stringio'
+require 'mini_histogram'
 
 module DerailedBenchmarks
   # A class used to read several benchmark files
@@ -103,11 +104,15 @@ module DerailedBenchmarks
     end
 
     def histogram(io = $stdout)
-      [newest, oldest].each do |report|
+      newest_histogram = MiniHistogram.new(newest.values)
+      oldest_histogram = MiniHistogram.new(oldest.values)
+      MiniHistogram.set_average_edges!(newest_histogram, oldest_histogram)
+
+      {newest => newest_histogram, oldest => oldest_histogram}.each do |report, histogram|
         plot = UnicodePlot.histogram(
-          report.values,
+          histogram,
           title: "\n#{' ' * 18 }Histogram - [#{report.name}] #{report.desc.inspect}",
-          ylabel: "Time (seconds)",
+          ylabel: "Time (s)",
           xlabel: "# of runs in range"
         )
         plot.render(io)

--- a/lib/derailed_benchmarks/tasks.rb
+++ b/lib/derailed_benchmarks/tasks.rb
@@ -88,7 +88,8 @@ namespace :perf do
 
         if (i % 50).zero?
           puts "Intermediate result"
-          stats.call.banner
+          stats.call
+          stats.banner
           puts "Continuing execution"
         end
       end
@@ -102,7 +103,8 @@ namespace :perf do
       end
 
       if stats
-        stats.call.banner
+        stats.call
+        stats.banner
 
         result_file = out_dir + "results.txt"
         File.open(result_file, "w") do |f|

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -36,7 +36,12 @@ class StatsFromDirTest < ActiveSupport::TestCase
     branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), name: "winner" }
     stats = DerailedBenchmarks::StatsFromDir.new(branch_info).call
 
-    puts stats.call.banner
+    io = StringIO.new
+    stats.call.banner(io)
+    puts io.string
+
+    assert_match(/11\.2 , 11\.28/, io.string)
+    assert_match(/11\.8 , 11\.88/, io.string)
   end
 
 

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -29,6 +29,17 @@ class StatsFromDirTest < ActiveSupport::TestCase
     assert_equal "11.3844", format % newest.median
   end
 
+  test "histogram output" do
+    dir = fixtures_dir("stats/significant")
+    branch_info = {}
+    branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
+    branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), name: "winner" }
+    stats = DerailedBenchmarks::StatsFromDir.new(branch_info).call
+
+    puts stats.call.banner
+  end
+
+
   test "alignment" do
     dir = fixtures_dir("stats/significant")
     branch_info = {}


### PR DESCRIPTION
Turns out that reducing a whole bunch of numbers to a single value (average for example, or median) means that we're getting rid of a huge amount of information. One way to add context back in without drowning users in raw data is to include a histogram in the output. 

With histograms in the output the user can see the distributions of their two runs to make better informed decisions about the validity of the data.

Here's an example histogram:

```
                              Histogram
              ┌                                        ┐
   [3.1, 3.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 23
   [3.2, 3.3) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 14
   [3.3, 3.4) ┤▇▇▇▇▇▇▇▇ 5
   [3.4, 3.5) ┤▇▇▇▇▇ 3
   [3.5, 3.6) ┤▇▇ 1
   [3.6, 3.7) ┤▇▇▇▇▇▇▇▇ 5
   [3.7, 3.8) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇ 8
   [3.8, 3.9) ┤▇▇▇ 2
              └                                        ┘
                              Frequency
```

Here's how the output looks in a test run:

```
👎👎👎(NOT Statistically Significant) 👎👎👎

[3054e1d584] "Merge pull request #36506 from kamipo/group_by_with_order_by_virtual_count_attribute" - (0.0201745 seconds)
  SLOWER 🐢🐢🐢 by:
      0.8833x [older/newer]
    -13.2063% [(older - newer) / older * 100]
[80f989aece] "Remove duplicated attribute alias resolution in `_select!`" - (0.017821 seconds)

Iterations per sample: 10
Samples: 2
Test type: Kolmogorov Smirnov
Confidence level: 95.0 %
Is significant? (max > critical): false
D critical: 1.7308183826022854
D max: 1.0

Histogram - [3054e1d584] "Merge pull request #36506 from kamipo/group_by_with_order_by_virtual_count_attribute"
                  ┌                                        ┐
   [0.015, 0.02 ) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1
   [0.02 , 0.025) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1
                  └                                        ┘
                                  Frequency

Histogram - [80f989aece] "Remove duplicated attribute alias resolution in `_select!`"
                  ┌                                        ┐
   [0.017, 0.018) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1
   [0.018, 0.019) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1
                  └                                        ┘
                                  Frequency


Output: tmp/compare_branches/2020-01-06-12-23-1578335006-352084000/results.txt
```

> Note it's not that interesting with only two samples



## Caveats

The histograms that are presented do not have identical/correct axis. So while the shape of the histograms are correct in comparison to each other, you cannot place them side by side for an accurate representation because they have different bin sizes and start from a different  value. 

In the short term I do think that the visual data being present with this caveat is better than nothing. In the long term support would need to be added to `unicode_plot` to support this behavior.

## Blockers

There is a bug that raises an error when 2 values are given to generate a histogram if the values have some special undetermined relationship. This is tracked here:

https://github.com/red-data-tools/unicode_plot.rb/issues/24