### PR TITLE
Fix infinite loop when Zeitwerk is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master (unreleased)
 
-- Fix bug with `Kernel#require` patch when Zeitwerk is enabled
+- Fix bug with `Kernel#require` patch when Zeitwerk is enabled (https://github.com/schneems/derailed_benchmarks/pull/170)
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix bug with `Kernel#require` patch when Zeitwerk is enabled
+
 ## 1.6.0
 
 - Added the `perf:app` command to compare commits within the same application. (https://github.com/schneems/derailed_benchmarks/pull/157)

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -26,7 +26,7 @@ class TasksTest < ActiveSupport::TestCase
     env_string = env.map {|key, value| "#{key.shellescape}=#{value.to_s.shellescape}" }.join(" ")
     cmd        = "env #{env_string} bundle exec rake -f perf.rake #{cmd} --trace"
     puts "Running: #{cmd}"
-    result = `cd '#{rails_app_path}' && #{cmd}`
+    result = Bundler.with_original_env { `cd '#{rails_app_path}' && #{cmd}` }
     if assert_success
       assert $?.success?, "Expected '#{cmd}' to return a success status.\nOutput: #{result}"
     end

--- a/test/rails_app/config/application.rb
+++ b/test/rails_app/config/application.rb
@@ -13,6 +13,8 @@ require 'devise'
 
 module Dummy
   class Application < Rails::Application
+    config.load_defaults Rails.version.to_f
+
     config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
@schneems I was having trouble running `perf:mem` when Zeitwerk is enabled.

I'm getting an infinite loop on the `require` because Zeitwerk also patches `require`:

```ruby
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:21:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk/kernel.rb:23:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:21:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk/kernel.rb:23:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:21:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk/kernel.rb:23:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:21:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk/kernel.rb:23:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:21:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk/kernel.rb:23:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:84:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:28:in `require_relative'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk.rb:11:in `<module:Zeitwerk>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk.rb:3:in `<top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:76:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:76:in `block (2 levels) in <top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:58:in `measure_memory_impact'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:72:in `block in <top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:84:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/railties-6.0.2/lib/rails/application/configuration.rb:310:in `autoloader='
/builds/gitlab-org/gitlab/config/application.rb:34:in `<class:Application>'
/builds/gitlab-org/gitlab/config/application.rb:16:in `<module:Gitlab>'
/builds/gitlab-org/gitlab/config/application.rb:15:in `<top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:76:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:76:in `block (2 levels) in <top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:58:in `measure_memory_impact'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:72:in `block in <top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/core_ext/kernel_require.rb:84:in `require'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/load_tasks.rb:21:in `block (2 levels) in <top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:273:in `block in execute'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:273:in `each'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:273:in `execute'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:214:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:194:in `invoke_with_call_chain'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:183:in `invoke'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/lib/derailed_benchmarks/load_tasks.rb:62:in `block (2 levels) in <top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:273:in `block in execute'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:273:in `each'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:273:in `execute'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:214:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:194:in `invoke_with_call_chain'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:238:in `block in invoke_prerequisites'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:236:in `each'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:236:in `invoke_prerequisites'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:213:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:194:in `invoke_with_call_chain'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/rake-12.3.3/lib/rake/task.rb:183:in `invoke'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/bin/derailed:42:in `exec'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/gems/derailed_benchmarks-1.6.0/bin/derailed:93:in `<top (required)>'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/bin/derailed:23:in `load'
/builds/gitlab-org/gitlab/vendor/ruby/2.6.0/bin/derailed:23:in `<top (required)>'
```

It seemed to be related to how we override `require`. See:

```ruby
From: /home/engwan/.asdf/installs/ruby/2.6.5/lib/ruby/gems/2.6.0/gems/zeitwerk-2.2.2/lib/zeitwerk/kernel.rb @ line 16 :

    11:   # already existing ancestor chains.
    12:   alias_method :zeitwerk_original_require, :require
    13: 
    14:   # @param path [String]
    15:   # @return [Boolean]
 => 16:   def require(path)
    17:     if loader = Zeitwerk::Registry.loader_for(path)
    18:       if path.end_with?(".rb")
    19:         zeitwerk_original_require(path).tap do |required|
    20:           loader.on_file_autoloaded(path) if required
    21:         end

[3] pry(Kernel)> self.method(:require).source_location
=> ["/home/engwan/.asdf/installs/ruby/2.6.5/lib/ruby/gems/2.6.0/gems/derailed_benchmarks-1.4.2/lib/derailed_benchmarks/core_ext/kernel_require.rb", 71]
[4] pry(Kernel)> self.method(:zeitwerk_original_require).source_location
=> ["/home/engwan/.asdf/installs/ruby/2.6.5/lib/ruby/gems/2.6.0/gems/derailed_benchmarks-1.4.2/lib/derailed_benchmarks/core_ext/kernel_require.rb", 20]
```

This makes it very similar to how Zeitwerk / Bootsnap overrides `require` and this prevents the infinite loop.

What do you think of this change?