### PR TITLE
Correct logging of unsuccessful curl requests to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master (unreleased)
 
+## [1.8.0] - unreleased
+
+- Correct logging of unsuccessful curl requests to file (https://github.com/schneems/derailed_benchmarks/pull/172)
+
 ## 1.7.0
 
 - Add histogram support to `perf:library` (https://github.com/schneems/derailed_benchmarks/pull/169)

--- a/lib/derailed_benchmarks/load_tasks.rb
+++ b/lib/derailed_benchmarks/load_tasks.rb
@@ -110,7 +110,7 @@ namespace :perf do
           STDERR.puts "Bad request to #{cmd.inspect} \n\n***RESPONSE***:\n\n#{ response.inspect }"
 
           FileUtils.mkdir_p("tmp")
-          File.open("tmp/fail.html", "w+") {|f| f.write response.body }
+          File.open("tmp/fail.html", "w+") {|f| f.write response }
 
           `open #{File.expand_path("tmp/fail.html")}` if ENV["DERAILED_DEBUG"]
 


### PR DESCRIPTION
The command in backticks only returns a string so no `.body` method is available. `response` is a string so we can write it to the file directly.