### PR TITLE
Explicit 2.2.0+ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.0
-  - 2.5.5
+  - 2.2.10
+  - 2.5.8
   - 2.7.1
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
+  - 2.2.0
   - 2.5.5
-  - 2.6.3
-  - ruby-head
+  - 2.7.1
 
 gemfile:
   - gemfiles/rails_5_1.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,5 @@ gemfile:
   - gemfiles/rails_git.gemfile
 
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 
-matrix:
-  allow_failures:
-    - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_install:
 jobs:
   allow_failures:
     - rvm: 2.2.10
-      gemfile: gemfiles/rails_git.gemfile
+      gemfile: gemfiles/rails_6_0.gemfile
     - rvm: 2.2.10
-      gemfile: gemfiles/rails_5_1.gemfile
+      gemfile: gemfiles/rails_git.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,15 @@ rvm:
 
 gemfile:
   - gemfiles/rails_5_1.gemfile
-  - gemfiles/rails_5_2.gemfile
   - gemfiles/rails_6_0.gemfile
   - gemfiles/rails_git.gemfile
 
 before_install:
   - gem install bundler -v 1.17.3
 
+jobs:
+  allow_failures:
+    - rvm: 2.2.10
+      gemfile: gemfiles/rails_git.gemfile
+    - rvm: 2.2.10
+      gemfile: gemfiles/rails_5_1.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## master (unreleased)
+## HEAD
+
+- Ruby 2.2 is now officialy supported and tested (https://github.com/schneems/derailed_benchmarks/pull/177)
 
 ## 1.7.0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A series of things you can use to benchmark a Rails or Ruby app.
 ## Compatibility/Requirements
 
 This gem has been tested and is known to work with Rails 3.2+ using Ruby
-2.1+. Some commands __may__ work on older versions of Ruby, but not all commands are supported.
+2.2+. Some commands __may__ work on older versions of Ruby, but not all commands are supported.
 
 For some benchmarks, not all, you'll need to verify you have a working version of curl on your OS:
 

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
   gem.add_dependency "ruby-statistics", ">= 2.1"
-  gem.add_dependency "mini_histogram",    ">= 0.2.0"
+  gem.add_dependency "mini_histogram",    ">= 0.2.1"
 
   gem.add_development_dependency "capybara",  "~> 2"
   gem.add_development_dependency "m"

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.1.0"
+  gem.required_ruby_version = ">= 2.2.0"
 
   gem.add_dependency "heapy",           "~> 0"
   gem.add_dependency "memory_profiler", "~> 0"
@@ -30,8 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
   gem.add_dependency "ruby-statistics", ">= 2.1"
-  gem.add_dependency "unicode_plot",    ">= 0.0.4", "< 1.0.0"
-  gem.add_dependency "mini_histogram",    "~> 0"
+  gem.add_dependency "mini_histogram",    ">= 0.2.0"
 
   gem.add_development_dependency "capybara",  "~> 2"
   gem.add_development_dependency "m"

--- a/lib/derailed_benchmarks/require_tree.rb
+++ b/lib/derailed_benchmarks/require_tree.rb
@@ -40,7 +40,7 @@ module DerailedBenchmarks
     end
 
     def to_string
-      str = +"#{name}: #{cost.round(4)} MiB"
+      str = String.new("#{name}: #{cost.round(4)} MiB")
       if parent && REQUIRED_BY[self.name.to_s]
         names = REQUIRED_BY[self.name.to_s].uniq - [parent.name.to_s]
         if names.any?

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -2,9 +2,9 @@
 
 require 'bigdecimal'
 require 'statistics'
-require 'unicode_plot'
 require 'stringio'
 require 'mini_histogram'
+require 'mini_histogram/plot'
 
 module DerailedBenchmarks
   # A class used to read several benchmark files
@@ -125,12 +125,12 @@ module DerailedBenchmarks
       MiniHistogram.set_average_edges!(newest_histogram, oldest_histogram)
 
       {newest => newest_histogram, oldest => oldest_histogram}.each do |report, histogram|
-        plot = UnicodePlot.histogram(
-          histogram,
+        plot = histogram.plot(
           title: "\n#{' ' * 18 }Histogram - [#{report.short_sha || report.name}] #{report.desc.inspect}",
           ylabel: "Time (s)",
           xlabel: "# of runs in range"
         )
+
         plot.render(io)
         io.puts
       end

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -103,13 +103,13 @@ class StatsFromDirTest < ActiveSupport::TestCase
       11.0
     end
 
-    expected = <<~EOM
-      [bbbbb] (10.5000 seconds) "I am the new commit" ref: "winner"
-        FASTER 🚀🚀🚀 by:
-          1.0476x [older/newer]
-          4.5455% [(older - newer) / older * 100]
-      [aaaaa] (11.0000 seconds) "Old commit" ref: "loser"
-    EOM
+    expected = <<-EOM
+[bbbbb] (10.5000 seconds) "I am the new commit" ref: "winner"
+  FASTER 🚀🚀🚀 by:
+    1.0476x [older/newer]
+    4.5455% [(older - newer) / older * 100]
+[aaaaa] (11.0000 seconds) "Old commit" ref: "loser"
+EOM
 
     actual = StringIO.new
     stats.banner(actual)
@@ -134,13 +134,13 @@ class StatsFromDirTest < ActiveSupport::TestCase
       11.0
     end
 
-    expected = <<~EOM
-      [loser] (11.0000 seconds) "I am the new commit" ref: "loser"
-        SLOWER 🐢🐢🐢 by:
-           0.9545x [older/newer]
-          -4.7619% [(older - newer) / older * 100]
-      [winner] (10.5000 seconds) "Old commit" ref: "winner"
-    EOM
+    expected = <<-EOM
+[loser] (11.0000 seconds) "I am the new commit" ref: "loser"
+  SLOWER 🐢🐢🐢 by:
+     0.9545x [older/newer]
+    -4.7619% [(older - newer) / older * 100]
+[winner] (10.5000 seconds) "Old commit" ref: "winner"
+EOM
 
     actual = StringIO.new
     stats.banner(actual)

--- a/test/fixtures/require/child_one.rb
+++ b/test/fixtures/require/child_one.rb
@@ -1,4 +1,4 @@
 class ChildOne
-  @retained = +""
+  @retained = String.new("")
   50_000.times.map { @retained << "A" }
 end

--- a/test/fixtures/require/child_two.rb
+++ b/test/fixtures/require/child_two.rb
@@ -1,5 +1,5 @@
 class ChildTwo
-  @retained = +""
+  @retained = String.new("")
   200_000.times.map { @retained << "A" }
 end
 

--- a/test/fixtures/require/parent_one.rb
+++ b/test/fixtures/require/parent_one.rb
@@ -1,5 +1,5 @@
 class ParentOne
-  @retained = +""
+  @retained = String.new("")
   1_000_000.times.map { @retained << "A" }
 end
 require File.expand_path('../child_one.rb', __FILE__)


### PR DESCRIPTION
Mostly as a response to https://github.com/schneems/derailed_benchmarks/issues/176#issuecomment-692615307

I want to follow Heroku's support. Heroku-16 provides Ruby 2.2 as the oldest version available. I want people on older rubies to find and fix perf issues on their apps where possible.