### PR TITLE
Print out histograms side-by-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Histograms are now printed side-by-side (https://github.com/schneems/derailed_benchmarks/pull/179)
+
 ## 1.8.1
 
 - Derailed now tracks memory use from `load` in addition to `require` (https://github.com/schneems/derailed_benchmarks/pull/178)

--- a/README.md
+++ b/README.md
@@ -448,11 +448,37 @@ When the test is done it will output which commit "won" and by how much:
 ```
 ❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️
 
-[7b4d80cb37] "1.8x Faster Partial Caching - Faster Cache Keys" - (10.9711965 seconds)
-  FASTER by:
-    1.0870x [older/newer]
-    8.0026% [(older - newer) / older * 100]
-[13d6aa3a7b] "Merge pull request #36284 from kamipo/fix_eager_loading_with_string_joins" - (11.9255485 seconds)
+[f1ab117] (11.3844 seconds) "I am the new commit" ref: "winner"
+  FASTER 🚀🚀🚀 by:
+    1.0062x [older/newer]
+    0.6147% [(older - newer) / older * 100]
+[5594a2d] (11.4548 seconds) "Old commit" ref: "loser"
+
+Iterations per sample:
+Samples: 100
+
+Test type: Kolmogorov Smirnov
+Confidence level: 99.0 %
+Is significant? (max > critical): true
+D critical: 0.2145966026289347
+D max: 0.26
+
+Histograms (time ranges are in seconds):
+
+   [f1ab117] description:                                        [5594a2d] description:
+     "I am the new commit"                                         "Old commit"
+                  ┌                                        ┐                    ┌                                        ┐
+   [11.2 , 11.28) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 12                             [11.2 , 11.28) ┤▇▇▇▇ 3
+   [11.28, 11.36) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 22                 [11.28, 11.36) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 19
+   [11.35, 11.43) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 30       [11.35, 11.43) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 17
+   [11.43, 11.51) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 17                       [11.43, 11.51) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 25
+   [11.5 , 11.58) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 13                           [11.5 , 11.58) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 15
+   [11.58, 11.66) ┤▇▇▇▇▇▇▇ 6                                     [11.58, 11.66) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 13
+   [11.65, 11.73) ┤ 0                                            [11.65, 11.73) ┤▇▇▇▇ 3
+   [11.73, 11.81) ┤ 0                                            [11.73, 11.81) ┤▇▇▇▇ 3
+   [11.8 , 11.88) ┤ 0                                            [11.8 , 11.88) ┤▇▇▇ 2
+                  └                                        ┘                    └                                        ┘
+                             # of runs in range                                            # of runs in range
 ```
 
 You can provide this to the Rails team along with the example app you used to benchmark (so they can independently verify if needed).

--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rake",            "> 10", "< 14"
   gem.add_dependency "thor",            ">= 0.19", "< 2"
   gem.add_dependency "ruby-statistics", ">= 2.1"
-  gem.add_dependency "mini_histogram",    ">= 0.2.1"
+  gem.add_dependency "mini_histogram",    ">= 0.3.0"
 
   gem.add_development_dependency "capybara",  "~> 2"
   gem.add_development_dependency "m"

--- a/lib/derailed_benchmarks/stats_from_dir.rb
+++ b/lib/derailed_benchmarks/stats_from_dir.rb
@@ -38,7 +38,7 @@ module DerailedBenchmarks
           file = info_hash.fetch(:file)
           desc = info_hash.fetch(:desc)
           time = info_hash.fetch(:time)
-          short_sha = info_hash["short_sha"]
+          short_sha = info_hash[:short_sha]
           @files << StatsForFile.new(file: file, desc: desc, time: time, name: branch, short_sha: short_sha)
         end
       else
@@ -120,21 +120,22 @@ module DerailedBenchmarks
     end
 
     def histogram(io = $stdout)
-      newest_histogram = MiniHistogram.new(newest.values)
-      oldest_histogram = MiniHistogram.new(oldest.values)
-      MiniHistogram.set_average_edges!(newest_histogram, oldest_histogram)
-
-      {newest => newest_histogram, oldest => oldest_histogram}.each do |report, histogram|
-        plot = histogram.plot(
-          title: "\n#{' ' * 18 }Histogram - [#{report.short_sha || report.name}] #{report.desc.inspect}",
-          ylabel: "Time (s)",
+      dual_histogram = MiniHistogram.dual_plot do |a, b|
+        a.values = newest.values
+        a.options = {
+          title: "\n   [#{newest.short_sha || newest.name}] description:\n     #{newest.desc.inspect}",
           xlabel: "# of runs in range"
-        )
-
-        plot.render(io)
-        io.puts
+        }
+        b.values = oldest.values
+        b.options = {
+          title: "\n   [#{oldest.short_sha || oldest.name}] description:\n     #{oldest.desc.inspect}",
+          xlabel: "# of runs in range"
+        }
       end
 
+      io.puts
+      io.puts "Histograms (time ranges are in seconds):"
+      io.puts(dual_histogram)
       io.puts
     end
 

--- a/test/derailed_benchmarks/stats_from_dir_test.rb
+++ b/test/derailed_benchmarks/stats_from_dir_test.rb
@@ -45,12 +45,14 @@ class StatsFromDirTest < ActiveSupport::TestCase
   test "histogram output" do
     dir = fixtures_dir("stats/significant")
     branch_info = {}
-    branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser.bench.txt"), name: "loser" }
-    branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), name: "winner" }
+    branch_info["loser"]  = { desc: "Old commit", time: Time.now, file: dir.join("loser.bench.txt"), short_sha: "5594a2d" }
+    branch_info["winner"] = { desc: "I am the new commit", time: Time.now + 1, file: dir.join("winner.bench.txt"), short_sha: "f1ab117" }
     stats = DerailedBenchmarks::StatsFromDir.new(branch_info).call
 
     io = StringIO.new
     stats.call.banner(io)
+
+    puts io.string
 
     assert_match(/11\.2 , 11\.28/, io.string)
     assert_match(/11\.8 , 11\.88/, io.string)


### PR DESCRIPTION
In an effort to make comparing distributions easier this PR puts the histogram data in a side-by-side format. The goal was a very loose approximation of a Violin plot https://en.wikipedia.org/wiki/Violin_plot.

Here's an example:

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

[f1ab117] (11.3844 seconds) "I am the new commit" ref: "winner"
  FASTER 🚀🚀🚀 by:
    1.0062x [older/newer]
    0.6147% [(older - newer) / older * 100]
[5594a2d] (11.4548 seconds) "Old commit" ref: "loser"

Iterations per sample:
Samples: 100

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.2145966026289347
D max: 0.26

Histograms (time ranges are in seconds):

   [f1ab117] description:                                        [5594a2d] description:
     "I am the new commit"                                         "Old commit"
                  ┌                                        ┐                    ┌                                        ┐
   [11.2 , 11.28) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 12                             [11.2 , 11.28) ┤▇▇▇▇ 3
   [11.28, 11.36) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 22                 [11.28, 11.36) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 19
   [11.35, 11.43) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 30       [11.35, 11.43) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 17
   [11.43, 11.51) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 17                       [11.43, 11.51) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 25
   [11.5 , 11.58) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 13                           [11.5 , 11.58) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 15
   [11.58, 11.66) ┤▇▇▇▇▇▇▇ 6                                     [11.58, 11.66) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 13
   [11.65, 11.73) ┤ 0                                            [11.65, 11.73) ┤▇▇▇▇ 3
   [11.73, 11.81) ┤ 0                                            [11.73, 11.81) ┤▇▇▇▇ 3
   [11.8 , 11.88) ┤ 0                                            [11.8 , 11.88) ┤▇▇▇ 2
                  └                                        ┘                    └                                        ┘
                             # of runs in range                                            # of runs in range

```


Extremely informal poll: https://twitter.com/schneems/status/1307884017740664832