### PR TITLE
Add support for memory_profiler 1.0

### DIFF
--- a/derailed_benchmarks.gemspec
+++ b/derailed_benchmarks.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.2.0"
 
   gem.add_dependency "heapy",           "~> 0"
-  gem.add_dependency "memory_profiler", "~> 0"
+  gem.add_dependency "memory_profiler", ">= 0", "< 2"
   gem.add_dependency "get_process_mem", "~> 0"
   gem.add_dependency "benchmark-ips",   "~> 2"
   gem.add_dependency "rack",            ">= 1"


### PR DESCRIPTION
On December 1st `memory_profiler 1.0` was released, with various optimizations: https://github.com/SamSaffron/memory_profiler/blob/master/CHANGELOG.md#100---02-12-2020

This new version of memory profiler removes support for Ruby 2.3 and Ruy 2.4.

Support for Ruby 2.2 (which `derailed_benchmarks` supports) was removed by version `0.9.13` which the current gemspec allows