### PR TITLE
Add `perf:heap_diff` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Add `perf:heap_diff` tool (https://github.com/schneems/derailed_benchmarks/pull/193)
+
 ## 2.0.1
 
 - `rack-test` dependency added (https://github.com/schneems/derailed_benchmarks/pull/187)

--- a/test/derailed_test.rb
+++ b/test/derailed_test.rb
@@ -11,4 +11,19 @@ class DerailedBenchmarksTest < ActiveSupport::TestCase
     assert DerailedBenchmarks.gem_is_bundled?("rack")
     refute DerailedBenchmarks.gem_is_bundled?("wicked")
   end
+
+  test "readme contains correct output" do
+    readme_path = File.join(__dir__, "..", "README.md")
+    lines = File.foreach(readme_path)
+    lineno = 1
+    expected = lines.lazy.drop_while { |line|
+      lineno += 1
+      line != "$ bundle exec derailed exec --help\n"
+    }.drop(1).take_while { |line| line != "```\n" }.force.join
+    assert_equal(
+      expected,
+      `bundle exec derailed exec --help`,
+      "Please update README.md:#{lineno}"
+    )
+  end
 end

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -153,6 +153,10 @@ class TasksTest < ActiveSupport::TestCase
   end
 
   test 'ips' do
-    rake "perf:mem_over_time"
+    rake "perf:ips"
+  end
+
+  test 'heap_diff' do
+    rake "perf:heap_diff", env: { "TEST_COUNT" => 5 }
   end
 end


### PR DESCRIPTION
Hi,

Thanks for the great tool, we just cleared out a significant memory leak in our app ! However, to do so we also needed a diff between heaps for a better view of what is retained. Since you mention SamSaffron in some parts of your repositories (for instance in heapy's README), I guessed this would be an ok addition.

I've tried to use a similar style and design as other tasks, please tell me if you need any change.

Articles I've cited seems great to me to, but please tell me if you prefer any other resource (which I may discover in the process :smile:)

