### PR TITLE
Fix Thor's deprecation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix Thor's deprecation warning by implementing `exit_on_failure?` (https://github.com/schneems/derailed_benchmarks/pull/195)
+
 ## 2.1.0
 
 - Add `perf:heap_diff` tool (https://github.com/schneems/derailed_benchmarks/pull/193)

--- a/bin/derailed
+++ b/bin/derailed
@@ -20,6 +20,9 @@ Bundler.setup
 require 'thor'
 
 class DerailedBenchmarkCLI < Thor
+  def self.exit_on_failure?
+    true
+  end
 
   desc "exec", "executes given derailed benchmark"
   def exec(task = nil)


### PR DESCRIPTION
Thor 1.0.0([CHANGELOG](https://github.com/rails/thor/blob/fb625b223465692a9d8a88cc2a483e126f1a8978/CHANGELOG.md#100)) has deprecated the behavior of relying on default `exit_on_failure?` Hence, making the devs define this method. 

Thor [#621](https://github.com/rails/thor/pull/621), [#625](https://github.com/rails/thor/pull/625)


PRIOR TO CHANGE:

```
bundle exec derailed exec perf:mem_over_time development
ERROR: "derailed exec" was called with arguments ["perf:mem_over_time", "development"]
Usage: "derailed exec"
Deprecation warning: Thor exit with status 0 on errors. To keep this behavior, you must define `exit_on_failure?` in `DerailedBenchmarkCLI`
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.

```

AFTER:

```
bundle exec derailed exec perf:mem_over_time development
ERROR: "derailed exec" was called with arguments ["perf:mem_over_time", "development"]
Usage: "derailed exec"
```